### PR TITLE
First Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Byte-compiled / optimized / DLL files
-__pycache__/
+*__pycache__/
 *.py[cod]
 *$py.class
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+
+# mcp-stargazing
+
+Calculate the altitude, rise, and set times of celestial objects (Sun, Moon, planets, stars, and deep-space objects) for any location on Earth.
+
+## Features
+- **Altitude/Azimuth Calculation**: Get elevation and compass direction for any celestial object.
+- **Rise/Set Times**: Determine when objects appear/disappear above the horizon.
+- **Supports**:
+  - Solar system objects (Sun, Moon, planets)
+  - Stars (e.g., "sirius")
+  - Deep-space objects (e.g., "andromeda", "orion_nebula")
+- **Time Zone Aware**: Works with local or UTC times.
+
+## Installation
+```bash
+pip install astropy pytz numpy astroquery
+```
+
+## Usage
+
+### Calculate Altitude/Azimuth
+```python src/main.py
+from src.celestial import celestial_pos
+from astropy.coordinates import EarthLocation
+import pytz
+from datetime import datetime
+
+# Observer location (New York)
+location = EarthLocation(lat=40.7128, lon=-74.0060)
+
+# Time (local timezone-aware)
+local_time = pytz.timezone("America/New_York").localize(datetime(2023, 10, 1, 12, 0))
+altitude, azimuth = celestial_pos("sun", location, local_time)
+print(f"Sun Position: Altitude={altitude:.1f}°, Azimuth={azimuth:.1f}°")
+```
+
+### Calculate Rise/Set Times
+```python src/main.py
+from src.celestial import celestial_rise_set
+
+rise, set_ = celestial_rise_set("andromeda", location, local_time.date())
+print(f"Andromeda: Rise={rise.iso}, Set={set_.iso}")
+```
+
+## API Reference (`src/celestial.py`)
+
+### `celestial_pos(celestial_object, observer_location, time)`
+- **Inputs**:
+  - `celestial_object`: Name (e.g., `"sun"`, `"andromeda"`).
+  - `observer_location`: `EarthLocation` object.
+  - `time`: `datetime` (timezone-aware) or Astropy `Time`.
+- **Returns**: `(altitude_degrees, azimuth_degrees)`.
+
+### `celestial_rise_set(celestial_object, observer_location, date, horizon=0.0)`
+- **Inputs**: 
+  - `date`: Timezone-aware `datetime`.
+  - `horizon`: Horizon elevation (default: 0°).
+- **Returns**: `(rise_time, set_time)` as UTC `Time` objects.
+
+## Testing
+Run tests with:
+```bash
+pytest tests/
+```
+
+### Key Test Cases (`tests/test_celestial.py`)
+```python tests/test_celestial.py
+def test_calculate_altitude_deepspace():
+    """Test deep-space object resolution."""
+    altitude, _ = celestial_pos("andromeda", NYC, Time.now())
+    assert -90 <= altitude <= 90
+
+def test_calculate_rise_set_sun():
+    """Validate Sun rise/set times."""
+    rise, set_ = celestial_rise_set("sun", NYC, datetime(2023, 10, 1))
+    assert rise < set_
+```
+
+## Project Structure
+```
+.
+├── src/
+│   ├── celestial.py     # Core calculations
+│   └── utils.py         # Time/location helpers
+├── tests/
+│   ├── test_celestial.py
+│   └── test_utils.py
+└── README.md
+```
+
+## Future Work
+- Add support for comets/asteroids.
+- Optimize SIMBAD queries for offline use.
+---
+### Key Updates:
+1. **Deep-Space Support**: Added examples for `"andromeda"` in usage and API docs.
+2. **Testing**: Highlighted deep-space and edge-case tests.
+3. **Dependencies**: Added `astroquery` for SIMBAD integration.
+4. **Structure**: Clarified file roles and test coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastmcp
+astropy
+pytz
+numpy
+astroquery

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+from setuptools import setup, find_packages
+name="mcp-stargazing"
+setup(
+    name="mcp-stargazing",
+    version="0.1.0",
+    description="Calculate celestial object positions and rise/set times",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    author="Henry Gong",
+    author_email="zhao.gong@outlook.com",
+    packages=find_packages(),
+    install_requires=[
+        "fastmcp",
+        "astropy>=5.0",
+        "pytz",
+        "numpy",
+        "astroquery"
+    ],
+    python_requires=">=3.8",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Astronomy",
+    ],
+    entry_points={
+        "console_scripts": [
+            f"{name}=src.main:main",
+        ],
+    },
+)

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,102 @@
+
+# mcp-stargazing
+
+Calculate the altitude, rise, and set times of celestial objects (Sun, Moon, planets, stars, and deep-space objects) for any location on Earth.
+
+## Features
+- **Solar System Objects**: Sun, Moon, and planets.
+- **Deep-Space Objects**: Stars (e.g., "sirius"), galaxies (e.g., "andromeda"), and nebulae.
+- **Precise Calculations**:
+  - Altitude/azimuth angles.
+  - Rise/set times with custom horizon elevation.
+- **Time Zone Support**: Works with local or UTC times.
+
+## Installation
+```bash
+pip install astropy pytz numpy astroquery
+```
+
+## Usage
+
+### Calculate Object Position
+```python src/main.py
+from src.celestial import celestial_pos
+from astropy.coordinates import EarthLocation
+from datetime import datetime
+import pytz
+
+# Observer location (New York)
+location = EarthLocation(lat=40.7128, lon=-74.0060, height=0)
+
+# Time (local timezone-aware)
+local_time = pytz.timezone("America/New_York").localize(datetime(2023, 10, 1, 12, 0))
+altitude, azimuth = celestial_pos("andromeda", location, local_time)
+print(f"Andromeda: Altitude={altitude:.1f}°, Azimuth={azimuth:.1f}°")
+```
+
+### Calculate Rise/Set Times
+```python src/main.py
+from src.celestial import celestial_rise_set
+
+rise, set_ = celestial_rise_set("moon", location, local_time.date(), horizon=5.0)
+print(f"Moon: Rise={rise.iso}, Set={set_.iso}")
+```
+
+## API Reference (`src/celestial.py`)
+
+### Core Functions
+```python src/celestial.py
+def celestial_pos(
+    celestial_object: str,  # "sun", "moon", "andromeda", etc.
+    observer_location: EarthLocation,
+    time: Union[Time, datetime]  # Timezone-aware if datetime
+) -> Tuple[float, float]:
+    """Returns (altitude_degrees, azimuth_degrees)."""
+```
+
+```python src/celestial.py
+def celestial_rise_set(
+    celestial_object: str,
+    observer_location: EarthLocation,
+    date: datetime,  # Timezone-aware
+    horizon: float = 0.0
+) -> Tuple[Optional[Time], Optional[Time]]:
+    """Returns (rise_time_utc, set_time_utc)."""
+```
+
+## Testing
+Run all tests:
+```bash
+pytest tests/
+```
+
+### Key Test Cases
+```python tests/test_celestial.py
+def test_deepspace_altitude():
+    """Test altitude calculation for Andromeda Galaxy."""
+    altitude, _ = celestial_pos("andromeda", NYC, Time.now())
+    assert -90 <= altitude <= 90
+
+def test_polar_night():
+    """Verify Sun never rises in Arctic winter."""
+    polar_loc = EarthLocation(lat=90*u.deg, lon=0)
+    rise, set_ = celestial_rise_set("sun", polar_loc, datetime(2023, 12, 22))
+    assert rise is None and set_ is None
+```
+
+## Project Structure
+```
+.
+├── src/
+│   ├── celestial.py     # Core calculations (rise/set, altitude)
+│   └── utils.py         # Timezone/location helpers
+├── tests/
+│   ├── test_celestial.py  # Unit tests for celestial.py
+│   └── test_utils.py     # Tests for utility functions
+└── README.md
+```
+
+## Future Work
+- Add offline catalog for deep-space objects.
+- Support for comets/asteroids.
+- Web API interface.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from . import celestial
+from . import main
+from . import utils

--- a/src/celestial.py
+++ b/src/celestial.py
@@ -1,0 +1,131 @@
+from astropy.time import Time
+from astropy.coordinates import (
+    EarthLocation,
+    AltAz,
+    get_sun,
+    get_moon,
+    get_body,
+    SkyCoord
+)
+import astropy.units as u
+from typing import Optional, Tuple, Union
+from datetime import datetime
+import numpy as np
+import pytz
+from astroquery.simbad import Simbad
+
+def celestial_pos(
+    celestial_object: str,
+    observer_location: EarthLocation,
+    time: Union[Time, datetime]
+) -> Tuple[float, float]:
+    """
+    Calculate the altitude and azimuth angles of a celestial object.
+    Args:
+        celestial_object: Name of the object ("sun", "moon", or planet name).
+        observer_location: Observer's EarthLocation.
+        time: Observation time (Astropy Time or timezone-aware datetime in LOCAL TIME).
+    Returns:
+        Tuple[float, float]: (altitude_degrees, azimuth_degrees).
+        - Altitude: Elevation above the horizon (0° = horizon, 90° = zenith).
+        - Azimuth: Compass direction (0° = North, 90° = East).
+    Raises:
+        ValueError: If the object is not supported or time is naive.
+    """
+    # Convert local time to UTC if input is datetime
+    if isinstance(time, datetime):
+        if time.tzinfo is None:
+            raise ValueError("Input datetime must be timezone-aware for local time.")
+        time = Time(time.astimezone(pytz.UTC))  # Convert to UTC
+    
+    obj_coord = _get_celestial_object(celestial_object, time)
+    altaz_frame = AltAz(obstime=time, location=observer_location)
+    altaz = obj_coord.transform_to(altaz_frame)
+    return altaz.alt.deg, altaz.az.deg  # Return (altitude, azimuth)
+
+def celestial_rise_set(
+    celestial_object: str,
+    observer_location: EarthLocation,
+    date: datetime,
+    horizon: float = 0.0
+) -> Tuple[Optional[Time], Optional[Time]]:
+    """
+    Calculate rise and set times of a celestial object.
+    Args:
+        celestial_object: Name of the object ("sun", "moon", or planet name).
+        observer_location: Observer's EarthLocation.
+        date: Date for calculation (timezone-aware datetime).
+        horizon: Horizon elevation in degrees (default: 0).
+    Returns:
+        Tuple[Optional[Time], Optional[Time]]: (rise_time, set_time) in UTC.
+    Raises:
+        ValueError: If the object is not supported or horizon is invalid.
+    """
+    if not -90 <= horizon <= 90:
+        raise ValueError("Horizon must be between -90 and 90 degrees.")
+    time_zone = pytz.timezone(zone=str(date.tzinfo))
+    origin_zone = pytz.timezone(zone='UTC')
+    # date = date.astimezone(time_zone)
+    time_grid = _generate_time_grid(date)
+    altitudes = np.array([
+        celestial_pos(celestial_object, observer_location, t)[0]
+        for t in time_grid
+    ])
+    def __convert_timezone(time):
+        t = time.to_datetime()
+        t = origin_zone.localize(t)
+        return t.astimezone(time_zone)
+    
+    rise_idx, set_idx = _find_rise_set_indices(altitudes, horizon)
+    rise_time = __convert_timezone(time_grid[rise_idx]) if rise_idx is not None else None
+    set_time = __convert_timezone(time_grid[set_idx]) if set_idx is not None else None
+    return rise_time, set_time
+
+def _get_celestial_object(name: str, time: Time) -> SkyCoord:
+    """Resolve a celestial object name to its SkyCoord.
+    Supports:
+    - Solar system objects (sun, moon, planets)
+    - Stars (e.g., "sirius")
+    - Deep-space objects (e.g., "andromeda", "orion_nebula")
+    """
+    name = name.lower()
+    
+    # Solar system objects
+    if name == "sun":
+        return get_sun(time)
+    elif name == "moon":
+        return get_body("moon", time)
+    elif name in ["mercury", "venus", "mars", "jupiter", "saturn", "uranus", "neptune"]:
+        return get_body(name, time)
+    
+    # Deep-space objects (stars, galaxies, nebulae)
+    try:
+        # Query SIMBAD for the object
+        result = Simbad.query_object(name)
+        if result is None:
+            raise ValueError(f"Object '{name}' not found in SIMBAD.")
+        
+        # Extract RA and Dec from the query result
+        ra = result["ra"][0]
+        dec = result["dec"][0]
+        return SkyCoord(ra, dec, unit=(u.hourangle, u.deg), frame='icrs')
+    
+    except Exception as e:
+        raise ValueError(f"Failed to resolve object '{name}': {str(e)}")
+    
+def _generate_time_grid(date: datetime) -> Time:
+    """Generate a grid of Time objects for the given date (5-minute intervals)."""
+    start = Time(date.replace(hour=0, minute=0, second=0))
+    end = Time(date.replace(hour=23, minute=59, second=59))
+    return start + np.linspace(0, 1, 288) * (end - start)  # 288 = 24h / 5min
+
+def _find_rise_set_indices(
+    altitudes: np.ndarray,
+    horizon: float
+) -> Tuple[Optional[int], Optional[int]]:
+    """Find indices where altitude crosses the horizon."""
+    above = altitudes > horizon
+    crossings = np.where(np.diff(above))[0]
+    rise_idx = crossings[0] if len(crossings) > 0 else None
+    set_idx = crossings[-1] if len(crossings) > 1 else None
+    return rise_idx, set_idx

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,87 @@
+from fastmcp import FastMCP
+from .celestial import celestial_pos, celestial_rise_set
+from typing import Tuple, Optional
+import datetime
+from astropy.time import Time
+from astropy.coordinates import EarthLocation
+import astropy.units as u
+import pytz
+
+# Initialize MCP instance
+mcp = FastMCP("mcp-stargazing")
+
+def process_location_and_time(
+    lon: float,
+    lat: float,
+    time: str,
+    time_zone: str
+) -> Tuple[EarthLocation, Time]:
+    """Process location and time inputs into standardized formats.
+
+    Args:
+        lon: Longitude in degrees
+        lat: Latitude in degrees
+        time: Time string in format "YYYY-MM-DD HH:MM:SS"
+        time_zone: IANA timezone string (e.g. "America/New_York")
+
+    Returns:
+        Tuple of (EarthLocation, Time) objects
+    """
+    earth_location = EarthLocation(lon=lon*u.deg, lat=lat*u.deg)
+    time = datetime.datetime.strptime(time, "%Y-%m-%d %H:%M:%S")
+    time_zone_info = pytz.timezone(time_zone)
+    time = time_zone_info.localize(time)
+    return earth_location, time
+
+@mcp.tool()
+def get_celestial_pos(
+    celestial_object: str,
+    lon: float,
+    lat: float,
+    time: str,
+    time_zone: str
+) -> Tuple[float, float]:
+    """Calculate the altitude and azimuth angles of a celestial object.
+
+    Args:
+        celestial_object: Name of object (e.g. "sun", "moon", "andromeda")
+        lon: Observer longitude in degrees
+        lat: Observer latitude in degrees
+        time: Observation time string "YYYY-MM-DD HH:MM:SS"
+        time_zone: IANA timezone string
+
+    Returns:
+        Tuple of (altitude_degrees, azimuth_degrees)
+    """
+    location, time_info = process_location_and_time(lon, lat, time, time_zone)
+    return celestial_pos(celestial_object, location, time_info)
+
+@mcp.tool()
+def get_celestial_rise_set(
+    celestial_object: str,
+    lon: float,
+    lat: float,
+    time: str,
+    time_zone: str
+) -> Tuple[Optional[Time], Optional[Time]]:
+    """Calculate the rise and set times of a celestial object.
+
+    Args:
+        celestial_object: Name of object (e.g. "sun", "moon", "andromeda")
+        lon: Observer longitude in degrees
+        lat: Observer latitude in degrees
+        time: Date string "YYYY-MM-DD HH:MM:SS"
+        time_zone: IANA timezone string
+
+    Returns:
+        Tuple of (rise_time, set_time) as UTC Time objects
+    """
+    location, time_info = process_location_and_time(lon, lat, time, time_zone)
+    return celestial_rise_set(celestial_object, location, time_info)
+
+def main():
+    """Run the MCP server."""
+    mcp.run()
+
+if __name__ == "__main__":
+    main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,40 @@
+from astropy import units as u
+from astropy.coordinates import EarthLocation
+from datetime import datetime
+import pytz
+
+def validate_coordinates(lat: float, lon: float) -> bool:
+    """Validate latitude and longitude values."""
+    return -90 <= lat <= 90 and -180 <= lon <= 180
+
+def create_earth_location(lat: float, lon: float, elevation: float = 0.0) -> EarthLocation:
+    """Create an EarthLocation object from coordinates."""
+    if not validate_coordinates(lat, lon):
+        raise ValueError(f"Invalid coordinates: lat={lat}, lon={lon}")
+    return EarthLocation(lat=lat * u.deg, lon=lon * u.deg, height=elevation * u.m)
+
+def parse_datetime(date_str: str, time_str: str, timezone: str = "UTC") -> datetime:
+    """
+    Parse a date string into a timezone-aware datetime object.
+    Note: Uses `pytz.timezone` for compatibility, but avoids direct comparison of tzinfo objects.
+    """
+    try:
+        tz = pytz.timezone(timezone)
+        naive_dt = datetime.strptime(date_str, "%Y-%m-%d")
+        return tz.localize(naive_dt)
+    except (ValueError, pytz.exceptions.UnknownTimeZoneError) as e:
+        raise ValueError(f"Invalid input: {e}")
+
+def localtime_to_utc(local_dt: datetime) -> datetime:
+    """
+    Convert a timezone-aware local datetime to UTC.
+    Args:
+        local_dt: Timezone-aware datetime object (e.g., from `parse_datetime`).
+    Returns:
+        datetime: UTC datetime (timezone-aware).
+    Raises:
+        ValueError: If input datetime is naive (not timezone-aware).
+    """
+    if local_dt.tzinfo is None:
+        raise ValueError("Input datetime must be timezone-aware.")
+    return local_dt.astimezone(pytz.UTC)

--- a/tests/test_celestial.py
+++ b/tests/test_celestial.py
@@ -1,0 +1,76 @@
+import pytest
+from src.celestial import (
+    celestial_pos,
+    celestial_rise_set,
+    _get_celestial_object,
+    _generate_time_grid
+)
+from astropy.time import Time
+from datetime import datetime, timedelta
+from astropy.coordinates import EarthLocation, SkyCoord
+import pytz
+import astropy.units as u
+import numpy as np
+
+# Test data
+NYC = EarthLocation(lat=40.7128*u.deg, lon=-74.0060*u.deg)
+UTC = pytz.timezone(zone='America/New_York')
+
+def test_calculate_altitude_sun():
+    """Test position calculation for the Sun at a known time."""
+    time = datetime(2023, 6, 22, 13, 0, 0)
+    time = UTC.localize(time)
+    altitude, _ = celestial_pos("sun", NYC, time)
+    assert 72 <= altitude <= 75
+def test_calculate_altitude_moon():
+    """Test position calculation for the Moon."""
+    time = datetime(2023, 10, 1, 18, 0, 0)
+    time = UTC.localize(time)
+    altitude, _ = celestial_pos("moon", NYC, time)
+    assert -90 <= altitude <= 90
+def test_calculate_altitude_deepspace():
+    """Test position calculation for deep-space objects (e.g., Andromeda)."""
+    time = Time(datetime.now())
+    altitude, _ = celestial_pos("andromeda", NYC, time)
+    assert -90 <= altitude <= 90
+
+def test_calculate_altitude_invalid_object():
+    """Test error handling for unsupported objects."""
+    with pytest.raises(ValueError, match="Failed to resolve object"):
+        celestial_pos("invalid_object", NYC, Time.now())
+
+def test_calculate_rise_set_sun():
+    """Test rise/set calculation for the Sun (should rise and set)."""
+    date = UTC.localize(datetime(2023, 10, 1))
+    rise, set_ = celestial_rise_set("sun", NYC, date)
+    assert rise is not None and set_ is not None
+    assert rise < set_
+
+def test_calculate_rise_set_deepspace():
+    """Test rise/set for deep-space objects (may not rise/set)."""
+    date = UTC.localize(datetime(2023, 10, 1))
+    rise, set_ = celestial_rise_set("andromeda", NYC, date)
+    assert rise is not None or set_ is not None
+
+def test_calculate_rise_set_invalid_horizon():
+    """Test invalid horizon elevation."""
+    with pytest.raises(ValueError, match="Horizon must be between"):
+        celestial_rise_set("sun", NYC, datetime(2023, 10, 1), horizon=100)
+
+def test__get_celestial_object():
+    """Test resolving celestial objects to SkyCoord."""
+    time = Time.now()
+    assert isinstance(_get_celestial_object("sun", time), SkyCoord)
+    assert isinstance(_get_celestial_object("Moon", time), SkyCoord)
+    assert isinstance(_get_celestial_object("Mars", time), SkyCoord)
+    assert isinstance(_get_celestial_object("andromeda", time), SkyCoord)
+    assert isinstance(_get_celestial_object("sirius", time), SkyCoord)
+def test__generate_time_grid():
+    """Test time grid generation (5-minute intervals over 24h)."""
+    date = UTC.localize(datetime(2023, 10, 1))
+    time_grid = _generate_time_grid(date)
+    assert len(time_grid) == 288
+    assert abs((time_grid[-1] - time_grid[0]).to_datetime().total_seconds() / 3600 - 24) < 1e-3
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+import pytest
+from src.utils import validate_coordinates, create_earth_location, parse_datetime, localtime_to_utc
+from astropy.coordinates import EarthLocation
+from datetime import datetime
+import pytz
+
+UTC=pytz.timezone("UTC")
+
+def test_validate_coordinates():
+    assert validate_coordinates(40.7128, -74.0060) is True
+    assert validate_coordinates(0, 0) is True
+    assert validate_coordinates(-90, 180) is True
+    assert validate_coordinates(91, -74.0060) is False
+
+def test_create_earth_location():
+    loc = create_earth_location(40.7128, -74.0060)
+    assert isinstance(loc, EarthLocation)
+    assert abs(loc.lat.deg - 40.7128) < 1e-5
+    assert abs(loc.lon.deg - -74.0060) < 1e-5
+    with pytest.raises(ValueError):
+        create_earth_location(100, -200)
+
+def test_parse_datetime():
+    dt = parse_datetime("2023-10-01", "America/New_York")
+    assert isinstance(dt, datetime)
+    assert dt.year == 2023
+    assert dt.month == 10
+    assert dt.day == 1
+    assert dt.tzinfo.zone == "UTC"
+
+def test_localtime_to_utc():
+    local_dt = parse_datetime("2023-10-01", "America/New_York")
+    utc_dt = localtime_to_utc(local_dt)
+    assert utc_dt.tzinfo == pytz.UTC
+    assert utc_dt.hour == local_dt.hour
+    with pytest.raises(ValueError):
+        localtime_to_utc(datetime(2023, 10, 1))
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
feat: Add support for deep-space objects in celestial calculations

- Extended `_get_celestial_object` to resolve deep-space objects (e.g., galaxies, stars) using SIMBAD queries.
- Updated `calculate_altitude` and `calculate_rise_set` to handle deep-space objects.
- Added tests for deep-space object resolution and edge cases.
- Improved error messages for unsupported objects.

Update mcp tool names

Correct rise and set time information

Update for packaging