### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-stargazing"
-version = "0.1.7"
+version = "0.2.0"
 description = "An MCP server that provides real-time astronomical data, smart stargazing planning, and light pollution analysis for AI agents."
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Bump version for the v0.2.0 release.\n\nAfter merging, re-tag and push:\n```\ngit tag -d v0.2.0\ngit push origin :v0.2.0\ngit tag v0.2.0\ngit push origin v0.2.0\n```