### PR TITLE
feat(weather): add multi-provider forecast aggregation

### DIFF
--- a/docs/weather-multi-provider-implementation-plan.md
+++ b/docs/weather-multi-provider-implementation-plan.md
@@ -1,0 +1,1072 @@
+# Weather Multi-Provider Implementation Plan
+
+## 1. Goal
+
+This document describes the implementation plan for refactoring the weather module into a multi-provider aggregation architecture.
+
+The target providers are:
+
+- `open-meteo`
+- `QWeather`
+- `wttr.in`
+
+The target behavior is:
+
+- Keep the existing MCP tool entrypoints stable.
+- Query all configured weather providers for a request.
+- Normalize provider responses into one internal schema.
+- Return one aggregated weather payload plus each provider's status and data.
+- Expose cloud-cover information as part of the public weather interface.
+- Expose hour-level forecast data as part of the public weather interface.
+- Keep the implementation simple, explicit, and easy to maintain.
+
+## 2. Design Principles
+
+- Keep `src/functions/weather/impl.py` as a thin MCP entry layer.
+- Move provider-specific logic into dedicated files under `src/functions/weather/providers/`.
+- Use one shared service layer to orchestrate provider lookup and aggregation.
+- Use one shared schema builder layer to keep response shape stable.
+- Prefer simple functions over complex inheritance or abstract frameworks.
+- Add function-level comments for newly created functions.
+- Keep the first version focused on correctness and clarity rather than advanced optimization.
+
+## 3. Target Query Behavior
+
+The weather tools should support the following provider modes:
+
+- `all`: query all weather providers
+- `qweather`: query only QWeather
+- `open-meteo`: query only Open-Meteo
+- `wttr`: query only wttr.in
+
+The default mode should be `all`.
+
+For `provider="all"`:
+
+- Query all enabled providers.
+- Keep the result even if one or more providers fail.
+- Return success if at least one provider succeeds.
+- Return an error only if all providers fail.
+
+## 4. Response Shape
+
+The final MCP `data` payload should follow this shape:
+
+```json
+{
+  "location": {
+    "name": "Beijing",
+    "lat": 39.9042,
+    "lon": 116.4074,
+    "timezone": "Asia/Shanghai"
+  },
+  "summary": {
+    "current": {
+      "temperature_c": 26.1,
+      "feels_like_c": 27.3,
+      "humidity": 58,
+      "wind_speed_kph": 12.3,
+      "wind_direction_deg": 230,
+      "pressure_hpa": 1008.4,
+      "visibility_km": 10.0,
+      "cloud_cover_percent": 72,
+      "cloud_cover_low_percent": 18,
+      "cloud_cover_mid_percent": 34,
+      "cloud_cover_high_percent": 52,
+      "weather_code": "partly_cloudy",
+      "weather_text": "Partly cloudy",
+      "observation_time": "2026-06-15T10:00:00+08:00"
+    },
+    "daily": [
+      {
+        "date": "2026-06-15",
+        "temp_min_c": 21.0,
+        "temp_max_c": 29.0,
+        "precipitation_probability": 0.35,
+        "cloud_cover_percent": 68,
+        "weather_code_day": "cloudy",
+        "weather_text_day": "Cloudy"
+      }
+    ],
+    "hourly": [
+      {
+        "time": "2026-06-15T11:00:00+08:00",
+        "temperature_c": 26.8,
+        "humidity": 56,
+        "precipitation_probability": 0.20,
+        "wind_speed_kph": 14.2,
+        "wind_direction_deg": 225,
+        "cloud_cover_percent": 70,
+        "cloud_cover_low_percent": 16,
+        "cloud_cover_mid_percent": 31,
+        "cloud_cover_high_percent": 50,
+        "weather_code": "partly_cloudy",
+        "weather_text": "Partly cloudy"
+      }
+    ]
+  },
+  "providers": {
+    "open-meteo": {
+      "status": "success",
+      "provider": "open-meteo",
+      "data": {}
+    },
+    "qweather": {
+      "status": "success",
+      "provider": "qweather",
+      "data": {}
+    },
+    "wttr": {
+      "status": "error",
+      "provider": "wttr",
+      "error": {
+        "code": "API_TIMEOUT",
+        "message": "wttr.in request timed out"
+      }
+    }
+  },
+  "source": {
+    "query_mode": "all",
+    "successful_providers": [
+      "open-meteo",
+      "qweather"
+    ],
+    "failed_providers": [
+      "wttr"
+    ],
+    "summary_provider_policy": "open-meteo-first"
+  }
+}
+```
+
+Cloud-cover fields are required for external consumers.
+
+Field notes:
+
+- `cloud_cover_percent`: total cloud cover percentage, recommended range \( 0 \le x \le 100 \)
+- `cloud_cover_low_percent`: low-cloud percentage when the provider exposes low-level cloud layers
+- `cloud_cover_mid_percent`: mid-cloud percentage when available
+- `cloud_cover_high_percent`: high-cloud percentage when available
+- `hourly`: hour-level forecast array using ISO timestamps in the `time` field
+
+Hourly forecast fields should be normalized to the same units as `summary.current`.
+
+If a provider does not expose layered cloud information, the layer-specific fields should be returned as `null`.
+
+## 5. Proposed File Layout
+
+```text
+src/functions/weather/
+├── __init__.py
+├── impl.py
+├── service.py
+├── models.py
+├── geocoding.py
+└── providers/
+    ├── __init__.py
+    ├── qweather.py
+    ├── open_meteo.py
+    └── wttr.py
+```
+
+## 6. File Responsibilities
+
+### `src/functions/weather/impl.py`
+
+Responsibilities:
+
+- Expose MCP tools with `@mcp.tool()`.
+- Validate user input.
+- Apply retry behavior around the service layer.
+- Call the service functions.
+- Wrap successful results with `format_response(...)`.
+- Surface structured failures with `MCPError`.
+
+This file should not:
+
+- Call provider-specific APIs directly.
+- Build summary logic.
+- Translate provider-specific fields.
+
+### `src/functions/weather/service.py`
+
+Responsibilities:
+
+- Resolve which providers should be queried.
+- Orchestrate provider lookup by coordinates.
+- Build the final aggregated response.
+- Decide provider success and failure handling.
+- Build `summary`, `providers`, and `source`.
+- Build `summary.hourly` as part of the external result.
+
+This is the main orchestration layer.
+
+### `src/functions/weather/models.py`
+
+Responsibilities:
+
+- Build stable payload shapes for weather data.
+- Provide helper constructors for `location`, `current`, `daily`, `hourly`, `provider`, and aggregated payloads.
+- Keep field naming consistent across all providers.
+- Ensure cloud-cover fields are normalized consistently across providers.
+
+### `src/functions/weather/geocoding.py`
+
+Responsibilities:
+
+- Resolve a place name into normalized location data.
+- Return `name`, `lat`, `lon`, and `timezone` when available.
+- Keep geocoding logic separate from provider weather logic.
+
+### `src/functions/weather/providers/qweather.py`
+
+Responsibilities:
+
+- Query QWeather weather endpoints.
+- Normalize QWeather fields into the shared weather schema.
+- Translate QWeather-specific errors into `MCPError`.
+- Map QWeather cloud data into the shared cloud-cover fields when available.
+- Map QWeather hourly forecast data when the upstream API exposes compatible hourly fields.
+
+### `src/functions/weather/providers/open_meteo.py`
+
+Responsibilities:
+
+- Query Open-Meteo by coordinates.
+- Normalize Open-Meteo fields into the shared weather schema.
+- Act as the preferred provider for `daily` forecast data in summary generation.
+- Treat Open-Meteo as the preferred source for cloud-cover data when cloud fields are available.
+- Act as the preferred provider for `hourly` forecast data in summary generation.
+
+### `src/functions/weather/providers/wttr.py`
+
+Responsibilities:
+
+- Query wttr.in by coordinates.
+- Normalize wttr.in fields into the shared weather schema.
+- Provide a lightweight supplemental provider in aggregated responses.
+- Surface cloud-cover data when wttr.in exposes it, otherwise keep cloud fields as `None`.
+- Surface hourly forecast data when wttr.in exposes it, otherwise keep hourly-only fields as `None`.
+
+## 7. Function Signatures And Responsibilities
+
+### 7.1 `impl.py`
+
+```python
+@mcp.tool()
+def get_weather_by_name(
+    place_name: str,
+    provider: str = "all",
+) -> dict:
+    """通过地点名称获取综合天气信息。"""
+```
+
+Responsibilities:
+
+- Validate that `place_name` is not empty.
+- Validate and normalize `provider`.
+- Call `service.get_aggregated_weather_by_name(...)`.
+- Return `format_response(...)`.
+
+```python
+@mcp.tool()
+def get_weather_by_position(
+    lat: float,
+    lon: float,
+    provider: str = "all",
+) -> dict:
+    """通过经纬度获取综合天气信息。"""
+```
+
+Responsibilities:
+
+- Validate coordinate bounds.
+- Validate and normalize `provider`.
+- Call `service.get_aggregated_weather_by_position(...)`.
+- Return `format_response(...)`.
+
+```python
+def _validate_provider(provider: str) -> str:
+    """校验 provider 参数并返回规范化值。"""
+```
+
+Responsibilities:
+
+- Normalize spaces and case.
+- Allow only `all`, `qweather`, `open-meteo`, `wttr`.
+- Raise `MCPError` on invalid input.
+
+```python
+def _validate_coordinates(lat: float, lon: float) -> None:
+    """校验经纬度是否合法。"""
+```
+
+Responsibilities:
+
+- Validate \( -90 \le lat \le 90 \).
+- Validate \( -180 \le lon \le 180 \).
+
+### 7.2 `service.py`
+
+```python
+def get_aggregated_weather_by_name(
+    place_name: str,
+    provider: str = "all",
+) -> dict:
+    """根据地点名称查询并聚合多个天气提供商的结果。"""
+```
+
+Responsibilities:
+
+- Call `geocoding.resolve_place_name(...)`.
+- Reuse the coordinate-based aggregation path.
+- Preserve resolved location metadata in the final payload.
+
+```python
+def get_aggregated_weather_by_position(
+    lat: float,
+    lon: float,
+    provider: str = "all",
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """根据经纬度查询并聚合多个天气提供商的结果。"""
+```
+
+Responsibilities:
+
+- Determine the active provider list.
+- Query each selected provider.
+- Build the final payload:
+  - `location`
+  - `summary`
+  - `providers`
+  - `source`
+- Raise an error only if all providers fail.
+
+```python
+def get_enabled_providers(provider: str) -> list[str]:
+    """根据 provider 参数返回需要查询的 provider 列表。"""
+```
+
+Responsibilities:
+
+- Return all providers for `all`.
+- Return a one-item list for a single provider mode.
+- Keep the canonical provider order stable.
+
+Suggested provider order:
+
+```python
+["open-meteo", "qweather", "wttr"]
+```
+
+```python
+def query_providers_by_position(
+    lat: float,
+    lon: float,
+    provider_names: list[str],
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """按 provider 列表查询天气，并返回各 provider 的结果状态。"""
+```
+
+Responsibilities:
+
+- Query each provider in order.
+- Collect `success` or `error` payloads.
+- Do not stop after one provider fails.
+
+```python
+def _query_single_provider(
+    provider_name: str,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询单个 provider 并返回标准化后的 provider 结果。"""
+```
+
+Responsibilities:
+
+- Route to `providers.qweather`, `providers.open_meteo`, or `providers.wttr`.
+- Return the standardized provider payload.
+
+```python
+def _build_summary(provider_results: dict) -> dict:
+    """根据多个 provider 的标准化结果生成综合天气摘要。"""
+```
+
+Responsibilities:
+
+- Read successful provider results only.
+- Build `summary.current`.
+- Build `summary.daily`.
+- Build `summary.hourly`.
+- Keep the logic explicit and easy to inspect.
+
+```python
+def _build_summary_current(successful_provider_data: list[dict]) -> dict:
+    """从多个成功 provider 中生成统一的当前天气摘要。"""
+```
+
+Responsibilities:
+
+- Select one primary provider for summary fields.
+- Fill missing fields from other successful providers when possible.
+- Keep field selection rules deterministic.
+
+```python
+def _build_summary_daily(successful_provider_data: list[dict]) -> list[dict]:
+    """从多个成功 provider 中生成统一的日级天气预报摘要。"""
+```
+
+Responsibilities:
+
+- Prefer Open-Meteo daily forecast when available.
+- Fall back to QWeather daily forecast if needed.
+- Fall back to wttr daily forecast if needed.
+
+```python
+def _build_summary_hourly(
+    successful_provider_data: list[dict],
+) -> list[dict]:
+    """从多个成功 provider 中生成统一的小时级天气预报摘要。"""
+```
+
+Responsibilities:
+
+- Prefer Open-Meteo hourly forecast when available.
+- Fall back to QWeather hourly forecast if needed.
+- Fall back to wttr hourly forecast if needed.
+- Preserve cloud-cover fields in each hourly forecast item whenever possible.
+
+```python
+def _select_primary_provider_for_summary(
+    successful_provider_data: list[dict],
+) -> str | None:
+    """选择用于生成摘要的主 provider。"""
+```
+
+Responsibilities:
+
+- Use a stable priority rule.
+- Suggested priority:
+  - `open-meteo`
+  - `qweather`
+  - `wttr`
+
+```python
+def _build_source_meta(
+    requested_provider: str,
+    provider_results: dict,
+) -> dict:
+    """根据 provider 查询结果构造来源元信息。"""
+```
+
+Responsibilities:
+
+- Collect successful provider names.
+- Collect failed provider names.
+- Declare the summary selection policy.
+
+```python
+def _ensure_any_provider_success(provider_results: dict) -> None:
+    """确保至少有一个 provider 查询成功，否则抛出错误。"""
+```
+
+Responsibilities:
+
+- Check whether any provider returned `status="success"`.
+- Raise an aggregated `MCPError` if all failed.
+
+### 7.3 `models.py`
+
+```python
+def build_location_payload(
+    name: str | None,
+    lat: float,
+    lon: float,
+    timezone: str | None,
+) -> dict:
+    """构造统一的位置数据结构。"""
+```
+
+Responsibilities:
+
+- Return the standard `location` object.
+
+```python
+def build_current_weather_payload(
+    temperature_c: float | None = None,
+    feels_like_c: float | None = None,
+    humidity: float | None = None,
+    wind_speed_kph: float | None = None,
+    wind_direction_deg: float | None = None,
+    pressure_hpa: float | None = None,
+    visibility_km: float | None = None,
+    cloud_cover_percent: float | None = None,
+    cloud_cover_low_percent: float | None = None,
+    cloud_cover_mid_percent: float | None = None,
+    cloud_cover_high_percent: float | None = None,
+    weather_code: str | None = None,
+    weather_text: str | None = None,
+    observation_time: str | None = None,
+) -> dict:
+    """构造统一的当前天气数据结构。"""
+```
+
+Responsibilities:
+
+- Build the shared `summary.current` shape.
+
+```python
+def build_daily_forecast_item(
+    date: str,
+    temp_min_c: float | None = None,
+    temp_max_c: float | None = None,
+    precipitation_probability: float | None = None,
+    cloud_cover_percent: float | None = None,
+    weather_code_day: str | None = None,
+    weather_text_day: str | None = None,
+) -> dict:
+    """构造统一的单日预报数据结构。"""
+```
+
+Responsibilities:
+
+- Build one normalized daily forecast item.
+- Keep daily cloud-cover output stable for external consumers.
+
+```python
+def build_hourly_forecast_item(
+    time: str,
+    temperature_c: float | None = None,
+    humidity: float | None = None,
+    precipitation_probability: float | None = None,
+    wind_speed_kph: float | None = None,
+    wind_direction_deg: float | None = None,
+    cloud_cover_percent: float | None = None,
+    cloud_cover_low_percent: float | None = None,
+    cloud_cover_mid_percent: float | None = None,
+    cloud_cover_high_percent: float | None = None,
+    weather_code: str | None = None,
+    weather_text: str | None = None,
+) -> dict:
+    """构造统一的单小时预报数据结构。"""
+```
+
+Responsibilities:
+
+- Build one normalized hourly forecast item.
+- Keep hourly cloud-cover output stable for external consumers.
+
+```python
+def build_provider_success_payload(
+    provider_name: str,
+    data: dict,
+) -> dict:
+    """构造 provider 成功状态结果。"""
+```
+
+Responsibilities:
+
+- Return the standard success wrapper for one provider.
+
+```python
+def build_provider_error_payload(
+    provider_name: str,
+    code: str,
+    message: str,
+    details: dict | None = None,
+) -> dict:
+    """构造 provider 失败状态结果。"""
+```
+
+Responsibilities:
+
+- Return the standard error wrapper for one provider.
+
+```python
+def build_aggregated_weather_payload(
+    location: dict,
+    summary: dict,
+    providers: dict,
+    source: dict,
+) -> dict:
+    """构造最终综合天气响应数据结构。"""
+```
+
+Responsibilities:
+
+- Assemble the final normalized result under `data`.
+
+### 7.4 `geocoding.py`
+
+```python
+def resolve_place_name(place_name: str) -> dict:
+    """将地点名称解析为标准位置对象。"""
+```
+
+Responsibilities:
+
+- Resolve place names to coordinates.
+- Return normalized location data:
+  - `name`
+  - `lat`
+  - `lon`
+  - `timezone`
+
+```python
+def _resolve_with_qweather(place_name: str) -> dict:
+    """使用 QWeather 地理接口解析地点名称。"""
+```
+
+Responsibilities:
+
+- Reuse the existing QWeather geocoding capability for the first version.
+- Return the best candidate from QWeather location search.
+
+```python
+def normalize_geocoding_result(
+    name: str,
+    lat: float,
+    lon: float,
+    timezone: str | None = None,
+) -> dict:
+    """将地理编码结果标准化为统一位置结构。"""
+```
+
+Responsibilities:
+
+- Convert raw geocoding output into the shared location format.
+
+### 7.5 `providers/qweather.py`
+
+```python
+def get_weather_by_position(
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询 QWeather 并返回标准化后的 provider 结果。"""
+```
+
+Responsibilities:
+
+- Fetch QWeather current weather and daily forecast.
+- Normalize the raw result.
+- Return one provider success payload.
+
+```python
+def fetch_qweather_raw_weather(lat: float, lon: float) -> dict:
+    """查询 QWeather 原始天气数据。"""
+```
+
+Responsibilities:
+
+- Fetch current weather and forecast from QWeather.
+- Return raw combined provider data.
+
+```python
+def normalize_qweather_weather(
+    raw_data: dict,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """将 QWeather 原始响应映射为统一天气结构。"""
+```
+
+Responsibilities:
+
+- Convert QWeather field names into shared schema fields.
+- Convert provider-specific condition code to internal code.
+- Map cloud-related fields into:
+  - `cloud_cover_percent`
+  - `cloud_cover_low_percent`
+  - `cloud_cover_mid_percent`
+  - `cloud_cover_high_percent`
+- Map any available hourly forecast entries into the shared `hourly` structure.
+
+```python
+def map_qweather_condition_code(code: str | None) -> str | None:
+    """将 QWeather 天气代码映射为内部统一 weather_code。"""
+```
+
+Responsibilities:
+
+- Map QWeather condition code to the internal weather code set.
+
+### 7.6 `providers/open_meteo.py`
+
+```python
+def get_weather_by_position(
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询 Open-Meteo 并返回标准化后的 provider 结果。"""
+```
+
+Responsibilities:
+
+- Fetch Open-Meteo weather data.
+- Normalize current and daily weather into the shared schema.
+- Return one provider success payload.
+
+```python
+def build_open_meteo_url(
+    lat: float,
+    lon: float,
+    timezone: str | None = None,
+) -> str:
+    """构造 Open-Meteo 请求 URL。"""
+```
+
+Responsibilities:
+
+- Build the full request URL with all required weather fields.
+
+```python
+def fetch_open_meteo_raw_weather(
+    lat: float,
+    lon: float,
+    timezone: str | None = None,
+) -> dict:
+    """查询 Open-Meteo 原始天气数据。"""
+```
+
+Responsibilities:
+
+- Perform the HTTP request.
+- Translate request failures into `MCPError`.
+
+```python
+def normalize_open_meteo_weather(
+    raw_data: dict,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """将 Open-Meteo 原始响应映射为统一天气结构。"""
+```
+
+Responsibilities:
+
+- Extract current weather.
+- Extract daily forecast.
+- Extract hourly forecast.
+- Preserve timezone when available.
+- Map Open-Meteo cloud fields into the shared cloud-cover fields.
+
+```python
+def map_open_meteo_weather_code(code: int | None) -> str | None:
+    """将 Open-Meteo 天气代码映射为内部统一 weather_code。"""
+```
+
+Responsibilities:
+
+- Convert Open-Meteo weather codes into the internal weather code set.
+
+### 7.7 `providers/wttr.py`
+
+```python
+def get_weather_by_position(
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询 wttr.in 并返回标准化后的 provider 结果。"""
+```
+
+Responsibilities:
+
+- Fetch wttr.in weather data.
+- Normalize the result into the shared schema.
+- Return one provider success payload.
+
+```python
+def build_wttr_query(lat: float, lon: float) -> str:
+    """构造 wttr.in 查询字符串。"""
+```
+
+Responsibilities:
+
+- Build a stable coordinate query format for wttr.in.
+
+```python
+def fetch_wttr_raw_weather(lat: float, lon: float) -> dict:
+    """查询 wttr.in 原始天气数据。"""
+```
+
+Responsibilities:
+
+- Perform the wttr.in request.
+- Translate request or response failures into `MCPError`.
+
+```python
+def normalize_wttr_weather(
+    raw_data: dict,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """将 wttr.in 原始响应映射为统一天气结构。"""
+```
+
+Responsibilities:
+
+- Extract current weather fields.
+- Extract daily forecast fields when available.
+- Extract hourly forecast fields when available.
+- Leave missing fields as `None`.
+- Populate cloud-cover fields when the upstream response includes cloud information.
+
+```python
+def map_wttr_condition_text(text: str | None) -> str | None:
+    """将 wttr.in 的天气文本映射为内部统一 weather_code。"""
+```
+
+Responsibilities:
+
+- Convert wttr.in condition text into internal weather code values.
+
+## 8. Summary Generation Rules
+
+The first version should keep summary logic simple and deterministic.
+
+### `summary.current`
+
+Suggested rules:
+
+- Select one primary provider using this priority:
+  - `open-meteo`
+  - `qweather`
+  - `wttr`
+- Take current-weather fields from the primary provider.
+- If a field is missing, fill it from other successful providers in priority order.
+- Prefer cloud-cover fields from `open-meteo` when available, because cloud amount is a key external requirement.
+
+### `summary.daily`
+
+Suggested rules:
+
+- Prefer `open-meteo` daily forecast.
+- Fall back to `qweather` daily forecast if Open-Meteo is unavailable.
+- Fall back to `wttr` daily forecast if both others are unavailable.
+- Preserve `cloud_cover_percent` in each daily item whenever at least one provider supplies it.
+
+### `summary.hourly`
+
+Suggested rules:
+
+- Prefer `open-meteo` hourly forecast.
+- Fall back to `qweather` hourly forecast if Open-Meteo is unavailable.
+- Fall back to `wttr` hourly forecast if both others are unavailable.
+- Preserve cloud-cover fields in each hourly item whenever at least one provider supplies them.
+- Use ISO timestamps for each hourly item in the `time` field.
+
+### Future Enhancement
+
+If needed later, selected numeric fields may use median-based aggregation. For example, if temperatures from three providers are \( T_1 \), \( T_2 \), and \( T_3 \), the summary temperature may be defined as:
+
+\[
+T_{\text{summary}} = \mathrm{median}(T_1, T_2, T_3)
+\]
+
+This should not be part of the first implementation.
+
+## 9. Error Handling Rules
+
+- Keep using `src.response.MCPError`.
+- Translate provider request failures into structured errors.
+- Do not leak raw provider exceptions to MCP tools.
+- Treat partial provider failure as a successful aggregated response.
+- Raise a top-level error only when all selected providers fail.
+
+Recommended mapping:
+
+- timeout -> `API_TIMEOUT`
+- authentication failure -> `API_AUTH_FAILURE`
+- rate limit -> `API_RATE_LIMIT`
+- invalid provider response -> `EXTERNAL_API_ERROR`
+- connectivity issue -> `NETWORK_ERROR`
+- invalid tool configuration -> `CONFIGURATION_ERROR`
+
+## 10. Implementation Phases
+
+### Phase 1: Create The Structure
+
+- Add `service.py`
+- Add `models.py`
+- Add `geocoding.py`
+- Add `providers/` package and provider files
+
+Output:
+
+- Weather module file layout is ready for provider-based implementation.
+
+### Phase 2: Migrate QWeather
+
+- Move QWeather-specific weather logic into `providers/qweather.py`
+- Reuse existing QWeather request and auth helpers where possible
+
+Output:
+
+- QWeather works through the new provider interface.
+
+### Phase 3: Add Open-Meteo
+
+- Implement Open-Meteo request URL builder
+- Fetch current, daily, and hourly weather
+- Normalize the response
+
+Output:
+
+- Open-Meteo works as a provider and can serve as summary primary source.
+
+### Phase 4: Add wttr.in
+
+- Implement wttr.in fetch and normalization
+- Support current weather, daily forecast, and hourly forecast where possible
+
+Output:
+
+- wttr.in works as a supplemental provider.
+
+### Phase 5: Implement Geocoding
+
+- Implement name-to-coordinate resolution in `geocoding.py`
+- Reuse QWeather geocoding for the first version
+
+Output:
+
+- `get_weather_by_name(...)` uses a shared location resolution path.
+
+### Phase 6: Implement Aggregation
+
+- Build `query_providers_by_position(...)`
+- Build summary logic
+- Build provider status collection
+- Build final payload assembly
+
+Output:
+
+- Weather service returns a unified aggregated result.
+
+### Phase 7: Update MCP Entry Layer
+
+- Refactor `impl.py` to call the service layer only
+- Add `provider: str = "all"`
+
+Output:
+
+- MCP tools expose the new behavior while keeping stable entrypoints.
+
+### Phase 8: Tests
+
+- Add provider normalization tests
+- Add aggregation tests
+- Update MCP weather tool tests
+
+Output:
+
+- New behavior is covered by tests.
+
+### Phase 9: Documentation
+
+- Update `README.md`
+- Update `AGENTS.md` if tool behavior changes materially
+
+Output:
+
+- The new weather tool behavior is documented for contributors and agent users.
+
+## 11. Test Plan
+
+Suggested test files:
+
+- `tests/test_weather.py`
+- `tests/test_weather_providers.py`
+- `tests/test_weather_normalization.py`
+
+Suggested test scenarios:
+
+- all providers succeed
+- one provider fails and others succeed
+- only one provider succeeds
+- all providers fail
+- geocoding succeeds
+- geocoding fails
+- explicit single-provider query works
+- normalized payload shape remains stable
+
+Recommended command:
+
+```bash
+pytest tests/ -v
+```
+
+## 12. First-Version Scope Control
+
+The first implementation should include:
+
+- provider mode selection
+- shared response schema
+- QWeather provider
+- Open-Meteo provider
+- wttr.in provider
+- shared geocoding
+- aggregated result payload
+- cloud-cover fields in `summary.current` and `summary.daily`
+- hourly forecast fields in `summary.hourly`
+- provider success and error visibility
+- tests for aggregation and normalization
+
+The first implementation should not include:
+
+- advanced async concurrency
+- weighted provider scoring
+- historical weather support
+- caching optimization
+- sophisticated multi-provider statistical fusion
+
+## 13. Recommended Build Order
+
+Recommended coding order:
+
+1. `models.py`
+2. `service.py` skeleton
+3. `providers/qweather.py`
+4. `providers/open_meteo.py`
+5. `providers/wttr.py`
+6. `geocoding.py`
+7. `impl.py`
+8. tests
+9. documentation updates
+
+## 14. Completion Criteria
+
+The implementation is complete when:
+
+- `get_weather_by_name(...)` works with `provider="all"`
+- `get_weather_by_position(...)` works with `provider="all"`
+- at least one provider success returns a valid aggregated payload
+- all provider failures return a structured top-level error
+- `summary`, `providers`, and `source` are present in the final result
+- `summary.hourly` exposes hour-level forecast data
+- provider results are normalized to a stable schema
+- tests pass from the project root
+
+## 15. Next Step
+
+The next practical step is to convert this plan into code skeleton files, then implement providers one by one in the recommended build order.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pytz",
     "numpy>=1.24,<2.4",
     "astroquery",
+    "requests",
     "rasterio",
     "tzlocal",
     "geopy",

--- a/src/functions/weather/geocoding.py
+++ b/src/functions/weather/geocoding.py
@@ -1,0 +1,71 @@
+"""Shared geocoding helpers for weather tools."""
+
+from geopy.exc import GeocoderServiceError, GeocoderTimedOut
+from geopy.geocoders import Nominatim
+
+from src.response import MCPError
+
+
+def resolve_place_name(place_name: str) -> dict:
+    """将地点名称解析为标准位置对象。"""
+
+    cleaned_name = place_name.strip()
+    if not cleaned_name:
+        raise MCPError(
+            MCPError.CONFIGURATION_ERROR,
+            "place_name 不能为空。",
+            {"place_name": place_name},
+        )
+
+    return _resolve_with_nominatim(cleaned_name)
+
+
+def _resolve_with_nominatim(place_name: str) -> dict:
+    """使用 Nominatim 地理编码服务解析地点名称。"""
+
+    geocoder = Nominatim(user_agent="mcp-stargazing")
+    try:
+        result = geocoder.geocode(place_name, exactly_one=True, addressdetails=True)
+    except GeocoderTimedOut as exc:
+        raise MCPError(
+            MCPError.API_TIMEOUT,
+            f"地理编码请求超时: {place_name}",
+            {"place_name": place_name},
+        ) from exc
+    except GeocoderServiceError as exc:
+        raise MCPError(
+            MCPError.NETWORK_ERROR,
+            f"地理编码服务请求失败: {place_name}",
+            {"place_name": place_name},
+        ) from exc
+
+    if result is None:
+        raise MCPError(
+            MCPError.EXTERNAL_API_ERROR,
+            f"未找到地点: {place_name}",
+            {"place_name": place_name},
+        )
+
+    display_name = getattr(result, "address", None) or place_name
+    return normalize_geocoding_result(
+        name=display_name,
+        lat=float(result.latitude),
+        lon=float(result.longitude),
+        timezone=None,
+    )
+
+
+def normalize_geocoding_result(
+    name: str,
+    lat: float,
+    lon: float,
+    timezone: str | None = None,
+) -> dict:
+    """将地理编码结果标准化为统一位置结构。"""
+
+    return {
+        "name": name,
+        "lat": lat,
+        "lon": lon,
+        "timezone": timezone,
+    }

--- a/src/functions/weather/impl.py
+++ b/src/functions/weather/impl.py
@@ -1,126 +1,104 @@
-import os
 from src.server_instance import mcp
-from src.qweather_interaction import qweather_get_weather_by_name, qweather_get_weather_by_position
+from src.functions.weather.providers.qweather import get_qweather_auth_from_env
+from src.functions.weather.service import (
+    get_aggregated_weather_by_name,
+    get_aggregated_weather_by_position,
+)
 from src.response import format_response, MCPError
 from src.retry import retry_on_failure, RetryConfig
 
 
 def _get_qweather_auth_from_env() -> tuple[str | None, str | None, str | None]:
-    """
-    从环境变量读取 QWeather 鉴权与 Host 配置。
+    """兼容旧测试入口，返回 QWeather 鉴权与 Host 配置。"""
 
-    优先级：
-    - JWT：QWEATHER_JWT_TOKEN（推荐）
-    - API KEY：QWEATHER_API_KEY（兼容旧用法）
-    - API Host：QWEATHER_API_HOST（建议配置；不配会回退公共域名）
-    """
-
-    api_key = os.getenv("QWEATHER_API_KEY")
-    jwt_token = os.getenv("QWEATHER_JWT_TOKEN")
-    api_host = os.getenv("QWEATHER_API_HOST")
-    if not api_key and not jwt_token:
-        raise MCPError(
-            MCPError.MISSING_API_KEY,
-            "QWEATHER_API_KEY 或 QWEATHER_JWT_TOKEN 环境变量未设置。",
-            {"required_vars": ["QWEATHER_API_KEY", "QWEATHER_JWT_TOKEN"]}
-        )
-    # normalize empty strings to None (Dockerfile may set ENV to "")
-    return api_key, jwt_token or None, api_host or None
+    return get_qweather_auth_from_env()
 
 
 @mcp.tool()
-def get_weather_by_name(place_name: str):
+def get_weather_by_name(place_name: str, provider: str = "all"):
     """
-    通过地点名称获取天气（实时 + 10 天预报）。
+    通过地点名称获取综合天气（当前 + 小时预报 + 日预报）。
 
     Args:
-        place_name: 地点名称（例如城市/区县），会先进行 POI/位置搜索再查询天气。
+        place_name: 地点名称（例如城市/区县）。
+        provider: provider 模式，可选 all/qweather/open-meteo/wttr。
 
     Returns:
         Dict，包含 keys: "data", "_meta"。
 
     Raises:
-        MCPError: For authentication failures, API errors, or network issues.
+        MCPError: For validation failures, API errors, or network issues.
     """
-    api_key, jwt_token, api_host = _get_qweather_auth_from_env()
-    
+    cleaned_name = place_name.strip()
+    if not cleaned_name:
+        raise MCPError(
+            MCPError.CONFIGURATION_ERROR,
+            "place_name 不能为空。",
+            {"place_name": place_name},
+        )
+    normalized_provider = _validate_provider(provider)
+
     @retry_on_failure(
         RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
         retryable_errors=(ConnectionError, TimeoutError, OSError)
     )
     def _fetch_weather():
-        try:
-            # 兼容旧签名：第二个位置参数仍然传 api_key（若使用 JWT 则为 None）
-            result = qweather_get_weather_by_name(
-                place_name,
-                api_key,
-                api_host=api_host,
-                jwt_token=jwt_token,
-            )
-            return result
-        except ValueError as e:
-            if "QWeather 请求失败" in str(e):
-                raise MCPError(
-                    MCPError.EXTERNAL_API_ERROR,
-                    f"QWeather API request failed for place '{place_name}': {e}",
-                    {"place_name": place_name}
-                ) from e
-            else:
-                raise MCPError(
-                    MCPError.CONFIGURATION_ERROR,
-                    f"QWeather configuration error: {e}",
-                    {"place_name": place_name}
-                ) from e
-        # Let ConnectionError, TimeoutError, OSError bubble up to retry decorator
-    
+        return get_aggregated_weather_by_name(cleaned_name, provider=normalized_provider)
+
     result = _fetch_weather()
     return format_response(result)
 
+
 @mcp.tool()
-def get_weather_by_position(lat: float, lon: float):
+def get_weather_by_position(lat: float, lon: float, provider: str = "all"):
     """
-    通过经纬度获取天气（实时 + 10 天预报）。
+    通过经纬度获取综合天气（当前 + 小时预报 + 日预报）。
 
     Args:
         lat: 纬度
         lon: 经度
+        provider: provider 模式，可选 all/qweather/open-meteo/wttr。
 
     Returns:
         Dict，包含 keys: "data", "_meta"。
 
     Raises:
-        MCPError: For authentication failures, API errors, or network issues.
+        MCPError: For validation failures, API errors, or network issues.
     """
-    api_key, jwt_token, api_host = _get_qweather_auth_from_env()
-    
+    _validate_coordinates(lat, lon)
+    normalized_provider = _validate_provider(provider)
+
     @retry_on_failure(
         RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
         retryable_errors=(ConnectionError, TimeoutError, OSError)
     )
     def _fetch_weather():
-        try:
-            result = qweather_get_weather_by_position(
-                lat,
-                lon,
-                api_key,
-                api_host=api_host,
-                jwt_token=jwt_token,
-            )
-            return result
-        except ValueError as e:
-            if "QWeather 请求失败" in str(e):
-                raise MCPError(
-                    MCPError.EXTERNAL_API_ERROR,
-                    f"QWeather API request failed for coordinates ({lat}, {lon}): {e}",
-                    {"lat": lat, "lon": lon}
-                ) from e
-            else:
-                raise MCPError(
-                    MCPError.CONFIGURATION_ERROR,
-                    f"QWeather configuration error: {e}",
-                    {"lat": lat, "lon": lon}
-                ) from e
-        # Let ConnectionError, TimeoutError, OSError bubble up to retry decorator
-    
+        return get_aggregated_weather_by_position(lat, lon, provider=normalized_provider)
+
     result = _fetch_weather()
     return format_response(result)
+
+
+def _validate_provider(provider: str) -> str:
+    """校验 provider 参数并返回规范化值。"""
+
+    normalized = provider.strip().lower()
+    allowed = {"all", "qweather", "open-meteo", "wttr"}
+    if normalized not in allowed:
+        raise MCPError(
+            MCPError.CONFIGURATION_ERROR,
+            f"不支持的天气 provider: {provider}",
+            {"provider": provider, "allowed": sorted(allowed)},
+        )
+    return normalized
+
+
+def _validate_coordinates(lat: float, lon: float) -> None:
+    """校验经纬度是否合法。"""
+
+    if not (-90 <= lat <= 90) or not (-180 <= lon <= 180):
+        raise MCPError(
+            MCPError.INVALID_COORDINATES,
+            f"Invalid coordinates: lat={lat}, lon={lon}",
+            {"lat": lat, "lon": lon},
+        )

--- a/src/functions/weather/models.py
+++ b/src/functions/weather/models.py
@@ -1,0 +1,154 @@
+"""Shared payload builders for aggregated weather responses."""
+
+
+def build_location_payload(
+    name: str | None,
+    lat: float,
+    lon: float,
+    timezone: str | None,
+) -> dict:
+    """构造统一的位置数据结构。"""
+
+    return {
+        "name": name,
+        "lat": lat,
+        "lon": lon,
+        "timezone": timezone,
+    }
+
+
+def build_current_weather_payload(
+    temperature_c: float | None = None,
+    feels_like_c: float | None = None,
+    humidity: float | None = None,
+    wind_speed_kph: float | None = None,
+    wind_direction_deg: float | None = None,
+    pressure_hpa: float | None = None,
+    visibility_km: float | None = None,
+    cloud_cover_percent: float | None = None,
+    cloud_cover_low_percent: float | None = None,
+    cloud_cover_mid_percent: float | None = None,
+    cloud_cover_high_percent: float | None = None,
+    weather_code: str | None = None,
+    weather_text: str | None = None,
+    observation_time: str | None = None,
+) -> dict:
+    """构造统一的当前天气数据结构。"""
+
+    return {
+        "temperature_c": temperature_c,
+        "feels_like_c": feels_like_c,
+        "humidity": humidity,
+        "wind_speed_kph": wind_speed_kph,
+        "wind_direction_deg": wind_direction_deg,
+        "pressure_hpa": pressure_hpa,
+        "visibility_km": visibility_km,
+        "cloud_cover_percent": cloud_cover_percent,
+        "cloud_cover_low_percent": cloud_cover_low_percent,
+        "cloud_cover_mid_percent": cloud_cover_mid_percent,
+        "cloud_cover_high_percent": cloud_cover_high_percent,
+        "weather_code": weather_code,
+        "weather_text": weather_text,
+        "observation_time": observation_time,
+    }
+
+
+def build_daily_forecast_item(
+    date: str,
+    temp_min_c: float | None = None,
+    temp_max_c: float | None = None,
+    precipitation_probability: float | None = None,
+    cloud_cover_percent: float | None = None,
+    weather_code_day: str | None = None,
+    weather_text_day: str | None = None,
+) -> dict:
+    """构造统一的单日预报数据结构。"""
+
+    return {
+        "date": date,
+        "temp_min_c": temp_min_c,
+        "temp_max_c": temp_max_c,
+        "precipitation_probability": precipitation_probability,
+        "cloud_cover_percent": cloud_cover_percent,
+        "weather_code_day": weather_code_day,
+        "weather_text_day": weather_text_day,
+    }
+
+
+def build_hourly_forecast_item(
+    time: str,
+    temperature_c: float | None = None,
+    humidity: float | None = None,
+    precipitation_probability: float | None = None,
+    wind_speed_kph: float | None = None,
+    wind_direction_deg: float | None = None,
+    cloud_cover_percent: float | None = None,
+    cloud_cover_low_percent: float | None = None,
+    cloud_cover_mid_percent: float | None = None,
+    cloud_cover_high_percent: float | None = None,
+    weather_code: str | None = None,
+    weather_text: str | None = None,
+) -> dict:
+    """构造统一的单小时预报数据结构。"""
+
+    return {
+        "time": time,
+        "temperature_c": temperature_c,
+        "humidity": humidity,
+        "precipitation_probability": precipitation_probability,
+        "wind_speed_kph": wind_speed_kph,
+        "wind_direction_deg": wind_direction_deg,
+        "cloud_cover_percent": cloud_cover_percent,
+        "cloud_cover_low_percent": cloud_cover_low_percent,
+        "cloud_cover_mid_percent": cloud_cover_mid_percent,
+        "cloud_cover_high_percent": cloud_cover_high_percent,
+        "weather_code": weather_code,
+        "weather_text": weather_text,
+    }
+
+
+def build_provider_success_payload(provider_name: str, data: dict) -> dict:
+    """构造 provider 成功状态结果。"""
+
+    return {
+        "status": "success",
+        "provider": provider_name,
+        "data": data,
+    }
+
+
+def build_provider_error_payload(
+    provider_name: str,
+    code: str,
+    message: str,
+    details: dict | None = None,
+) -> dict:
+    """构造 provider 失败状态结果。"""
+
+    error = {
+        "code": code,
+        "message": message,
+    }
+    if details:
+        error["details"] = details
+    return {
+        "status": "error",
+        "provider": provider_name,
+        "error": error,
+    }
+
+
+def build_aggregated_weather_payload(
+    location: dict,
+    summary: dict,
+    providers: dict,
+    source: dict,
+) -> dict:
+    """构造最终综合天气响应数据结构。"""
+
+    return {
+        "location": location,
+        "summary": summary,
+        "providers": providers,
+        "source": source,
+    }

--- a/src/functions/weather/providers/__init__.py
+++ b/src/functions/weather/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Weather provider adapters."""

--- a/src/functions/weather/providers/open_meteo.py
+++ b/src/functions/weather/providers/open_meteo.py
@@ -1,0 +1,291 @@
+"""Open-Meteo provider adapter."""
+
+import requests
+
+from src.functions.weather.models import (
+    build_current_weather_payload,
+    build_daily_forecast_item,
+    build_hourly_forecast_item,
+    build_provider_success_payload,
+)
+from src.response import MCPError
+
+OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast"
+
+
+def get_weather_by_position(
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询 Open-Meteo 并返回标准化后的 provider 结果。"""
+
+    raw_data = fetch_open_meteo_raw_weather(lat, lon, timezone=timezone)
+    normalized = normalize_open_meteo_weather(
+        raw_data,
+        lat,
+        lon,
+        location_name=location_name,
+        timezone=timezone,
+    )
+    return build_provider_success_payload("open-meteo", normalized)
+
+
+def build_open_meteo_url(
+    lat: float,
+    lon: float,
+    timezone: str | None = None,
+) -> str:
+    """构造 Open-Meteo 请求 URL。"""
+
+    request = requests.Request("GET", OPEN_METEO_URL, params=_build_open_meteo_params(lat, lon, timezone))
+    prepared = request.prepare()
+    if prepared.url is None:
+        raise MCPError(
+            MCPError.CONFIGURATION_ERROR,
+            "Open-Meteo 请求 URL 构造失败。",
+            {"lat": lat, "lon": lon},
+        )
+    return prepared.url
+
+
+def fetch_open_meteo_raw_weather(
+    lat: float,
+    lon: float,
+    timezone: str | None = None,
+) -> dict:
+    """查询 Open-Meteo 原始天气数据。"""
+
+    try:
+        response = requests.get(
+            OPEN_METEO_URL,
+            params=_build_open_meteo_params(lat, lon, timezone),
+            timeout=15.0,
+        )
+        response.raise_for_status()
+    except requests.exceptions.Timeout as exc:
+        raise MCPError(
+            MCPError.API_TIMEOUT,
+            "Open-Meteo 请求超时。",
+            {"lat": lat, "lon": lon},
+        ) from exc
+    except requests.exceptions.ConnectionError as exc:
+        raise MCPError(
+            MCPError.NETWORK_ERROR,
+            "Open-Meteo 网络连接失败。",
+            {"lat": lat, "lon": lon},
+        ) from exc
+    except requests.exceptions.HTTPError as exc:
+        raise MCPError(
+            MCPError.EXTERNAL_API_ERROR,
+            f"Open-Meteo 返回 HTTP {response.status_code}。",
+            {"lat": lat, "lon": lon, "status_code": response.status_code},
+        ) from exc
+    except requests.exceptions.RequestException as exc:
+        raise MCPError(
+            MCPError.NETWORK_ERROR,
+            f"Open-Meteo 请求失败: {exc}",
+            {"lat": lat, "lon": lon},
+        ) from exc
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise MCPError(
+            MCPError.EXTERNAL_API_ERROR,
+            "Open-Meteo 返回了无效 JSON。",
+            {"lat": lat, "lon": lon},
+        ) from exc
+
+
+def normalize_open_meteo_weather(
+    raw_data: dict,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """将 Open-Meteo 原始响应映射为统一天气结构。"""
+
+    current = raw_data.get("current", {})
+    daily = raw_data.get("daily", {})
+    hourly = raw_data.get("hourly", {})
+    resolved_timezone = raw_data.get("timezone", timezone)
+
+    return {
+        "location": {
+            "name": location_name,
+            "lat": lat,
+            "lon": lon,
+            "timezone": resolved_timezone,
+        },
+        "current": build_current_weather_payload(
+            temperature_c=_to_float(current.get("temperature_2m")),
+            feels_like_c=_to_float(current.get("apparent_temperature")),
+            humidity=_to_float(current.get("relative_humidity_2m")),
+            wind_speed_kph=_to_float(current.get("wind_speed_10m")),
+            wind_direction_deg=_to_float(current.get("wind_direction_10m")),
+            pressure_hpa=_to_float(current.get("pressure_msl")),
+            visibility_km=_meters_to_km(current.get("visibility")),
+            cloud_cover_percent=_to_float(current.get("cloud_cover")),
+            cloud_cover_low_percent=_to_float(current.get("cloud_cover_low")),
+            cloud_cover_mid_percent=_to_float(current.get("cloud_cover_mid")),
+            cloud_cover_high_percent=_to_float(current.get("cloud_cover_high")),
+            weather_code=map_open_meteo_weather_code(current.get("weather_code")),
+            weather_text=_weather_text_from_open_meteo_code(current.get("weather_code")),
+            observation_time=current.get("time"),
+        ),
+        "daily": [
+            build_daily_forecast_item(
+                date=date,
+                temp_min_c=_safe_index(daily.get("temperature_2m_min"), idx),
+                temp_max_c=_safe_index(daily.get("temperature_2m_max"), idx),
+                precipitation_probability=_percent_index_to_ratio(daily.get("precipitation_probability_max"), idx),
+                cloud_cover_percent=_safe_index(daily.get("cloud_cover_mean"), idx),
+                weather_code_day=map_open_meteo_weather_code(_safe_index(daily.get("weather_code"), idx)),
+                weather_text_day=_weather_text_from_open_meteo_code(_safe_index(daily.get("weather_code"), idx)),
+            )
+            for idx, date in enumerate(daily.get("time", []))
+        ],
+        "hourly": [
+            build_hourly_forecast_item(
+                time=time_value,
+                temperature_c=_safe_index(hourly.get("temperature_2m"), idx),
+                humidity=_safe_index(hourly.get("relative_humidity_2m"), idx),
+                precipitation_probability=_percent_index_to_ratio(hourly.get("precipitation_probability"), idx),
+                wind_speed_kph=_safe_index(hourly.get("wind_speed_10m"), idx),
+                wind_direction_deg=_safe_index(hourly.get("wind_direction_10m"), idx),
+                cloud_cover_percent=_safe_index(hourly.get("cloud_cover"), idx),
+                cloud_cover_low_percent=_safe_index(hourly.get("cloud_cover_low"), idx),
+                cloud_cover_mid_percent=_safe_index(hourly.get("cloud_cover_mid"), idx),
+                cloud_cover_high_percent=_safe_index(hourly.get("cloud_cover_high"), idx),
+                weather_code=map_open_meteo_weather_code(_safe_index(hourly.get("weather_code"), idx)),
+                weather_text=_weather_text_from_open_meteo_code(_safe_index(hourly.get("weather_code"), idx)),
+            )
+            for idx, time_value in enumerate(hourly.get("time", []))
+        ],
+    }
+
+
+def map_open_meteo_weather_code(code: int | None) -> str | None:
+    """将 Open-Meteo 天气代码映射为内部统一 weather_code。"""
+
+    if code is None:
+        return None
+    if code == 0:
+        return "clear"
+    if code in {1, 2, 3, 45, 48}:
+        return "partly_cloudy"
+    if code in {51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 80, 81, 82}:
+        return "rain"
+    if code in {71, 73, 75, 77, 85, 86}:
+        return "snow"
+    if code in {95, 96, 99}:
+        return "thunderstorm"
+    return "unknown"
+
+
+def _build_open_meteo_params(lat: float, lon: float, timezone: str | None) -> dict:
+    """构造 Open-Meteo 请求参数。"""
+
+    return {
+        "latitude": lat,
+        "longitude": lon,
+        "timezone": timezone or "auto",
+        "current": ",".join([
+            "temperature_2m",
+            "apparent_temperature",
+            "relative_humidity_2m",
+            "wind_speed_10m",
+            "wind_direction_10m",
+            "pressure_msl",
+            "visibility",
+            "cloud_cover",
+            "cloud_cover_low",
+            "cloud_cover_mid",
+            "cloud_cover_high",
+            "weather_code",
+        ]),
+        "hourly": ",".join([
+            "temperature_2m",
+            "relative_humidity_2m",
+            "precipitation_probability",
+            "wind_speed_10m",
+            "wind_direction_10m",
+            "cloud_cover",
+            "cloud_cover_low",
+            "cloud_cover_mid",
+            "cloud_cover_high",
+            "weather_code",
+        ]),
+        "daily": ",".join([
+            "temperature_2m_min",
+            "temperature_2m_max",
+            "precipitation_probability_max",
+            "cloud_cover_mean",
+            "weather_code",
+        ]),
+    }
+
+
+def _weather_text_from_open_meteo_code(code: int | None) -> str | None:
+    """将 Open-Meteo 天气代码映射为简短文本。"""
+
+    mapping = {
+        0: "Clear",
+        1: "Mainly clear",
+        2: "Partly cloudy",
+        3: "Overcast",
+        45: "Fog",
+        48: "Depositing rime fog",
+        51: "Light drizzle",
+        53: "Drizzle",
+        55: "Dense drizzle",
+        61: "Slight rain",
+        63: "Rain",
+        65: "Heavy rain",
+        71: "Slight snow",
+        73: "Snow",
+        75: "Heavy snow",
+        80: "Rain showers",
+        81: "Rain showers",
+        82: "Violent rain showers",
+        95: "Thunderstorm",
+        96: "Thunderstorm with hail",
+        99: "Thunderstorm with hail",
+    }
+    return mapping.get(code, "Unknown") if code is not None else None
+
+
+def _to_float(value: int | float | None) -> float | None:
+    """将输入值安全转换为浮点数。"""
+
+    if value is None:
+        return None
+    return float(value)
+
+
+def _meters_to_km(value: int | float | None) -> float | None:
+    """将米转换为千米。"""
+
+    if value is None:
+        return None
+    return float(value) / 1000.0
+
+
+def _safe_index(values: list | None, index: int) -> float | int | None:
+    """安全读取数组中的指定位置。"""
+
+    if values is None or index >= len(values):
+        return None
+    return values[index]
+
+
+def _percent_index_to_ratio(values: list | None, index: int) -> float | None:
+    """安全读取百分比数组并转换为 0 到 1 之间的小数。"""
+
+    value = _safe_index(values, index)
+    if value is None:
+        return None
+    return float(value) / 100.0

--- a/src/functions/weather/providers/qweather.py
+++ b/src/functions/weather/providers/qweather.py
@@ -1,0 +1,194 @@
+"""QWeather provider adapter."""
+
+import os
+
+from src.functions.weather.models import (
+    build_current_weather_payload,
+    build_daily_forecast_item,
+    build_hourly_forecast_item,
+    build_provider_success_payload,
+)
+from src.qweather_interaction import (
+    qweather_get_weather_by_coord_in_ten_days,
+    qweather_get_weather_by_coord_in_twenty_four_hours,
+    qweather_get_weather_by_coord_real_time,
+)
+from src.response import MCPError
+
+
+def get_qweather_auth_from_env() -> tuple[str | None, str | None, str | None]:
+    """从环境变量读取 QWeather 鉴权与 Host 配置。"""
+
+    api_key = os.getenv("QWEATHER_API_KEY")
+    jwt_token = os.getenv("QWEATHER_JWT_TOKEN")
+    api_host = os.getenv("QWEATHER_API_HOST")
+    if not api_key and not jwt_token:
+        raise MCPError(
+            MCPError.MISSING_API_KEY,
+            "QWEATHER_API_KEY 或 QWEATHER_JWT_TOKEN 环境变量未设置。",
+            {"required_vars": ["QWEATHER_API_KEY", "QWEATHER_JWT_TOKEN"]},
+        )
+    return api_key, jwt_token or None, api_host or None
+
+
+def get_weather_by_position(
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询 QWeather 并返回标准化后的 provider 结果。"""
+
+    raw_data = fetch_qweather_raw_weather(lat, lon)
+    normalized = normalize_qweather_weather(
+        raw_data,
+        lat,
+        lon,
+        location_name=location_name,
+        timezone=timezone,
+    )
+    return build_provider_success_payload("qweather", normalized)
+
+
+def fetch_qweather_raw_weather(lat: float, lon: float) -> dict:
+    """查询 QWeather 原始天气数据。"""
+
+    api_key, jwt_token, api_host = get_qweather_auth_from_env()
+    return {
+        "current": qweather_get_weather_by_coord_real_time(
+            lon,
+            lat,
+            api_key,
+            api_host=api_host,
+            jwt_token=jwt_token,
+        ),
+        "daily": qweather_get_weather_by_coord_in_ten_days(
+            lon,
+            lat,
+            api_key,
+            api_host=api_host,
+            jwt_token=jwt_token,
+        ),
+        "hourly": qweather_get_weather_by_coord_in_twenty_four_hours(
+            lon,
+            lat,
+            api_key,
+            api_host=api_host,
+            jwt_token=jwt_token,
+        ),
+    }
+
+
+def normalize_qweather_weather(
+    raw_data: dict,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """将 QWeather 原始响应映射为统一天气结构。"""
+
+    current = raw_data.get("current", {}).get("now", {})
+    daily_rows = raw_data.get("daily", {}).get("daily", [])
+    hourly_rows = raw_data.get("hourly", {}).get("hourly", [])
+
+    return {
+        "location": {
+            "name": location_name,
+            "lat": lat,
+            "lon": lon,
+            "timezone": timezone,
+        },
+        "current": build_current_weather_payload(
+            temperature_c=_to_float(current.get("temp")),
+            feels_like_c=_to_float(current.get("feelsLike")),
+            humidity=_to_float(current.get("humidity")),
+            wind_speed_kph=_to_float(current.get("windSpeed")),
+            wind_direction_deg=_to_float(current.get("wind360")),
+            pressure_hpa=_to_float(current.get("pressure")),
+            visibility_km=_to_float(current.get("vis")),
+            cloud_cover_percent=_to_float(current.get("cloud")),
+            cloud_cover_low_percent=None,
+            cloud_cover_mid_percent=None,
+            cloud_cover_high_percent=None,
+            weather_code=map_qweather_condition_code(current.get("icon")),
+            weather_text=current.get("text"),
+            observation_time=current.get("obsTime"),
+        ),
+        "daily": [
+            build_daily_forecast_item(
+                date=row.get("fxDate"),
+                temp_min_c=_to_float(row.get("tempMin")),
+                temp_max_c=_to_float(row.get("tempMax")),
+                precipitation_probability=_to_ratio(row.get("precip")),
+                cloud_cover_percent=_to_float(row.get("cloud")),
+                weather_code_day=map_qweather_condition_code(row.get("iconDay")),
+                weather_text_day=row.get("textDay"),
+            )
+            for row in daily_rows
+            if row.get("fxDate")
+        ],
+        "hourly": [
+            build_hourly_forecast_item(
+                time=row.get("fxTime"),
+                temperature_c=_to_float(row.get("temp")),
+                humidity=_to_float(row.get("humidity")),
+                precipitation_probability=_to_ratio(row.get("pop")),
+                wind_speed_kph=_to_float(row.get("windSpeed")),
+                wind_direction_deg=_to_float(row.get("wind360")),
+                cloud_cover_percent=_to_float(row.get("cloud")),
+                cloud_cover_low_percent=None,
+                cloud_cover_mid_percent=None,
+                cloud_cover_high_percent=None,
+                weather_code=map_qweather_condition_code(row.get("icon")),
+                weather_text=row.get("text"),
+            )
+            for row in hourly_rows
+            if row.get("fxTime")
+        ],
+    }
+
+
+def map_qweather_condition_code(code: str | None) -> str | None:
+    """将 QWeather 天气代码映射为内部统一 weather_code。"""
+
+    if code is None:
+        return None
+
+    cloudy_codes = {"100", "101", "102", "103", "104"}
+    rain_codes = {
+        "300", "301", "302", "303", "304", "305", "306", "307", "308", "309",
+        "310", "311", "312", "313", "314", "315", "316", "317", "318", "350",
+        "351", "399",
+    }
+    snow_codes = {"400", "401", "402", "403", "404", "405", "406", "407", "408", "409", "410", "456", "457", "499"}
+    fog_codes = {"500", "501", "502", "503", "504", "507", "508", "509", "510", "511", "512", "513", "514", "515"}
+
+    if code == "100":
+        return "clear"
+    if code in cloudy_codes:
+        return "partly_cloudy"
+    if code in rain_codes:
+        return "rain"
+    if code in snow_codes:
+        return "snow"
+    if code in fog_codes:
+        return "fog"
+    return "unknown"
+
+
+def _to_float(value: str | int | float | None) -> float | None:
+    """将输入值安全转换为浮点数。"""
+
+    if value in (None, ""):
+        return None
+    return float(value)
+
+
+def _to_ratio(value: str | int | float | None) -> float | None:
+    """将百分比值转换为 0 到 1 之间的小数。"""
+
+    numeric = _to_float(value)
+    if numeric is None:
+        return None
+    return numeric / 100.0

--- a/src/functions/weather/providers/wttr.py
+++ b/src/functions/weather/providers/wttr.py
@@ -1,0 +1,246 @@
+"""wttr.in provider adapter."""
+
+import requests
+
+from src.functions.weather.models import (
+    build_current_weather_payload,
+    build_daily_forecast_item,
+    build_hourly_forecast_item,
+    build_provider_success_payload,
+)
+from src.response import MCPError
+
+
+def get_weather_by_position(
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询 wttr.in 并返回标准化后的 provider 结果。"""
+
+    raw_data = fetch_wttr_raw_weather(lat, lon)
+    normalized = normalize_wttr_weather(
+        raw_data,
+        lat,
+        lon,
+        location_name=location_name,
+        timezone=timezone,
+    )
+    return build_provider_success_payload("wttr", normalized)
+
+
+def build_wttr_query(lat: float, lon: float) -> str:
+    """构造 wttr.in 查询字符串。"""
+
+    return f"{lat},{lon}"
+
+
+def fetch_wttr_raw_weather(lat: float, lon: float) -> dict:
+    """查询 wttr.in 原始天气数据。"""
+
+    try:
+        response = requests.get(
+            f"https://wttr.in/{build_wttr_query(lat, lon)}",
+            params={"format": "j1"},
+            timeout=15.0,
+        )
+        response.raise_for_status()
+    except requests.exceptions.Timeout as exc:
+        raise MCPError(
+            MCPError.API_TIMEOUT,
+            "wttr.in 请求超时。",
+            {"lat": lat, "lon": lon},
+        ) from exc
+    except requests.exceptions.ConnectionError as exc:
+        raise MCPError(
+            MCPError.NETWORK_ERROR,
+            "wttr.in 网络连接失败。",
+            {"lat": lat, "lon": lon},
+        ) from exc
+    except requests.exceptions.HTTPError as exc:
+        raise MCPError(
+            MCPError.EXTERNAL_API_ERROR,
+            f"wttr.in 返回 HTTP {response.status_code}。",
+            {"lat": lat, "lon": lon, "status_code": response.status_code},
+        ) from exc
+    except requests.exceptions.RequestException as exc:
+        raise MCPError(
+            MCPError.NETWORK_ERROR,
+            f"wttr.in 请求失败: {exc}",
+            {"lat": lat, "lon": lon},
+        ) from exc
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise MCPError(
+            MCPError.EXTERNAL_API_ERROR,
+            "wttr.in 返回了无效 JSON。",
+            {"lat": lat, "lon": lon},
+        ) from exc
+
+
+def normalize_wttr_weather(
+    raw_data: dict,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """将 wttr.in 原始响应映射为统一天气结构。"""
+
+    current = (raw_data.get("current_condition") or [{}])[0]
+    weather_rows = raw_data.get("weather", [])
+    nearest_area = (raw_data.get("nearest_area") or [{}])[0]
+    if location_name is None:
+        area_names = nearest_area.get("areaName") or []
+        if area_names:
+            location_name = area_names[0].get("value")
+
+    daily_items: list[dict] = []
+    hourly_items: list[dict] = []
+    for weather_row in weather_rows:
+        hourly_rows = weather_row.get("hourly") or []
+        daily_items.append(
+            build_daily_forecast_item(
+                date=weather_row.get("date"),
+                temp_min_c=_to_float(weather_row.get("mintempC")),
+                temp_max_c=_to_float(weather_row.get("maxtempC")),
+                precipitation_probability=_hourly_max_ratio(hourly_rows, "chanceofrain"),
+                cloud_cover_percent=_hourly_average(hourly_rows, "cloudcover"),
+                weather_code_day=map_wttr_condition_text(_condition_text_from_row(hourly_rows[0]) if hourly_rows else None),
+                weather_text_day=_condition_text_from_row(hourly_rows[0]) if hourly_rows else None,
+            )
+        )
+        hourly_items.extend(_build_hourly_items(weather_row.get("date"), hourly_rows))
+
+    return {
+        "location": {
+            "name": location_name,
+            "lat": lat,
+            "lon": lon,
+            "timezone": timezone,
+        },
+        "current": build_current_weather_payload(
+            temperature_c=_to_float(current.get("temp_C")),
+            feels_like_c=_to_float(current.get("FeelsLikeC")),
+            humidity=_to_float(current.get("humidity")),
+            wind_speed_kph=_to_float(current.get("windspeedKmph")),
+            wind_direction_deg=_to_float(current.get("winddirDegree")),
+            pressure_hpa=_to_float(current.get("pressure")),
+            visibility_km=_to_float(current.get("visibility")),
+            cloud_cover_percent=_to_float(current.get("cloudcover")),
+            cloud_cover_low_percent=None,
+            cloud_cover_mid_percent=None,
+            cloud_cover_high_percent=None,
+            weather_code=map_wttr_condition_text(_condition_text_from_row(current)),
+            weather_text=_condition_text_from_row(current),
+            observation_time=current.get("localObsDateTime"),
+        ),
+        "daily": [item for item in daily_items if item["date"]],
+        "hourly": hourly_items,
+    }
+
+
+def map_wttr_condition_text(text: str | None) -> str | None:
+    """将 wttr.in 的天气文本映射为内部统一 weather_code。"""
+
+    if text is None:
+        return None
+    normalized = text.lower()
+    if "sun" in normalized or "clear" in normalized:
+        return "clear"
+    if "cloud" in normalized or "overcast" in normalized:
+        return "partly_cloudy"
+    if "rain" in normalized or "drizzle" in normalized or "shower" in normalized:
+        return "rain"
+    if "snow" in normalized or "ice" in normalized or "blizzard" in normalized:
+        return "snow"
+    if "fog" in normalized or "mist" in normalized or "haze" in normalized:
+        return "fog"
+    if "thunder" in normalized:
+        return "thunderstorm"
+    return "unknown"
+
+
+def _build_hourly_items(date_value: str | None, hourly_rows: list[dict]) -> list[dict]:
+    """构造 wttr.in 的小时级预报列表。"""
+
+    items: list[dict] = []
+    for row in hourly_rows:
+        time_value = _combine_wttr_date_and_time(date_value, row.get("time"))
+        if time_value is None:
+            continue
+        items.append(
+            build_hourly_forecast_item(
+                time=time_value,
+                temperature_c=_to_float(row.get("tempC")),
+                humidity=_to_float(row.get("humidity")),
+                precipitation_probability=_percent_text_to_ratio(row.get("chanceofrain")),
+                wind_speed_kph=_to_float(row.get("windspeedKmph")),
+                wind_direction_deg=_to_float(row.get("winddirDegree")),
+                cloud_cover_percent=_to_float(row.get("cloudcover")),
+                cloud_cover_low_percent=None,
+                cloud_cover_mid_percent=None,
+                cloud_cover_high_percent=None,
+                weather_code=map_wttr_condition_text(_condition_text_from_row(row)),
+                weather_text=_condition_text_from_row(row),
+            )
+        )
+    return items
+
+
+def _combine_wttr_date_and_time(date_value: str | None, time_value: str | None) -> str | None:
+    """将 wttr.in 的日期和时间字段拼成 ISO 风格的时间字符串。"""
+
+    if not date_value or time_value is None:
+        return None
+    hour = int(time_value) // 100
+    if hour == 24:
+        hour = 0
+    return f"{date_value}T{hour:02d}:00:00"
+
+
+def _condition_text_from_row(row: dict) -> str | None:
+    """从 wttr.in 行数据中提取天气文本。"""
+
+    values = row.get("weatherDesc") or []
+    if values and isinstance(values, list):
+        return values[0].get("value")
+    return None
+
+
+def _to_float(value: str | int | float | None) -> float | None:
+    """将输入值安全转换为浮点数。"""
+
+    if value in (None, ""):
+        return None
+    return float(value)
+
+
+def _percent_text_to_ratio(value: str | int | float | None) -> float | None:
+    """将百分比文本转换为 0 到 1 之间的小数。"""
+
+    numeric = _to_float(value)
+    if numeric is None:
+        return None
+    return numeric / 100.0
+
+
+def _hourly_average(rows: list[dict], key: str) -> float | None:
+    """计算逐小时字段的平均值。"""
+
+    values = [_to_float(row.get(key)) for row in rows if _to_float(row.get(key)) is not None]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _hourly_max_ratio(rows: list[dict], key: str) -> float | None:
+    """计算逐小时百分比字段的最大值并转为小数。"""
+
+    values = [_to_float(row.get(key)) for row in rows if _to_float(row.get(key)) is not None]
+    if not values:
+        return None
+    return max(values) / 100.0

--- a/src/functions/weather/service.py
+++ b/src/functions/weather/service.py
@@ -1,0 +1,258 @@
+"""Aggregation service for multi-provider weather queries."""
+
+from src.functions.weather.geocoding import resolve_place_name
+from src.functions.weather.models import (
+    build_aggregated_weather_payload,
+    build_current_weather_payload,
+    build_location_payload,
+    build_provider_error_payload,
+)
+from src.functions.weather.providers import open_meteo, qweather, wttr
+from src.response import MCPError
+
+PROVIDER_ORDER = ["open-meteo", "qweather", "wttr"]
+
+
+def get_aggregated_weather_by_name(
+    place_name: str,
+    provider: str = "all",
+) -> dict:
+    """根据地点名称查询并聚合多个天气提供商的结果。"""
+
+    location = resolve_place_name(place_name)
+    return get_aggregated_weather_by_position(
+        location["lat"],
+        location["lon"],
+        provider=provider,
+        location_name=location.get("name"),
+        timezone=location.get("timezone"),
+    )
+
+
+def get_aggregated_weather_by_position(
+    lat: float,
+    lon: float,
+    provider: str = "all",
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """根据经纬度查询并聚合多个天气提供商的结果。"""
+
+    provider_names = get_enabled_providers(provider)
+    provider_results = query_providers_by_position(
+        lat,
+        lon,
+        provider_names,
+        location_name=location_name,
+        timezone=timezone,
+    )
+    _ensure_any_provider_success(provider_results)
+
+    successful_provider_data = [
+        {"provider": result["provider"], "data": result["data"]}
+        for result in provider_results.values()
+        if result["status"] == "success"
+    ]
+    location_payload = _build_location(lat, lon, location_name, timezone, successful_provider_data)
+    summary = _build_summary(successful_provider_data)
+    source = _build_source_meta(provider, provider_results)
+    return build_aggregated_weather_payload(
+        location=location_payload,
+        summary=summary,
+        providers=provider_results,
+        source=source,
+    )
+
+
+def get_enabled_providers(provider: str) -> list[str]:
+    """根据 provider 参数返回需要查询的 provider 列表。"""
+
+    if provider == "all":
+        return PROVIDER_ORDER[:]
+    if provider in PROVIDER_ORDER:
+        return [provider]
+    raise MCPError(
+        MCPError.CONFIGURATION_ERROR,
+        f"不支持的天气 provider: {provider}",
+        {"provider": provider, "allowed": ["all", *PROVIDER_ORDER]},
+    )
+
+
+def query_providers_by_position(
+    lat: float,
+    lon: float,
+    provider_names: list[str],
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """按 provider 列表查询天气，并返回各 provider 的结果状态。"""
+
+    results: dict[str, dict] = {}
+    for provider_name in provider_names:
+        try:
+            results[provider_name] = _query_single_provider(
+                provider_name,
+                lat,
+                lon,
+                location_name=location_name,
+                timezone=timezone,
+            )
+        except MCPError as exc:
+            results[provider_name] = build_provider_error_payload(
+                provider_name,
+                exc.code,
+                exc.message,
+                exc.details,
+            )
+        except Exception as exc:
+            results[provider_name] = build_provider_error_payload(
+                provider_name,
+                MCPError.EXTERNAL_API_ERROR,
+                f"{provider_name} provider 查询失败: {exc}",
+                {"lat": lat, "lon": lon},
+            )
+    return results
+
+
+def _query_single_provider(
+    provider_name: str,
+    lat: float,
+    lon: float,
+    location_name: str | None = None,
+    timezone: str | None = None,
+) -> dict:
+    """查询单个 provider 并返回标准化后的 provider 结果。"""
+
+    if provider_name == "open-meteo":
+        return open_meteo.get_weather_by_position(lat, lon, location_name=location_name, timezone=timezone)
+    if provider_name == "qweather":
+        return qweather.get_weather_by_position(lat, lon, location_name=location_name, timezone=timezone)
+    if provider_name == "wttr":
+        return wttr.get_weather_by_position(lat, lon, location_name=location_name, timezone=timezone)
+    raise MCPError(
+        MCPError.CONFIGURATION_ERROR,
+        f"未知 provider: {provider_name}",
+        {"provider": provider_name},
+    )
+
+
+def _build_summary(successful_provider_data: list[dict]) -> dict:
+    """根据多个 provider 的标准化结果生成综合天气摘要。"""
+
+    return {
+        "current": _build_summary_current(successful_provider_data),
+        "daily": _build_summary_daily(successful_provider_data),
+        "hourly": _build_summary_hourly(successful_provider_data),
+    }
+
+
+def _build_summary_current(successful_provider_data: list[dict]) -> dict:
+    """从多个成功 provider 中生成统一的当前天气摘要。"""
+
+    primary_provider = _select_primary_provider_for_summary(successful_provider_data)
+    primary_data = next(
+        (item["data"]["current"] for item in successful_provider_data if item["provider"] == primary_provider),
+        {},
+    )
+    merged = build_current_weather_payload(**primary_data)
+
+    for field_name in merged:
+        if merged[field_name] is not None:
+            continue
+        for item in successful_provider_data:
+            value = item["data"].get("current", {}).get(field_name)
+            if value is not None:
+                merged[field_name] = value
+                break
+    return merged
+
+
+def _build_summary_daily(successful_provider_data: list[dict]) -> list[dict]:
+    """从多个成功 provider 中生成统一的日级天气预报摘要。"""
+
+    for provider_name in PROVIDER_ORDER:
+        for item in successful_provider_data:
+            if item["provider"] == provider_name and item["data"].get("daily"):
+                return item["data"]["daily"]
+    return []
+
+
+def _build_summary_hourly(successful_provider_data: list[dict]) -> list[dict]:
+    """从多个成功 provider 中生成统一的小时级天气预报摘要。"""
+
+    for provider_name in PROVIDER_ORDER:
+        for item in successful_provider_data:
+            if item["provider"] == provider_name and item["data"].get("hourly"):
+                return item["data"]["hourly"]
+    return []
+
+
+def _select_primary_provider_for_summary(successful_provider_data: list[dict]) -> str | None:
+    """选择用于生成摘要的主 provider。"""
+
+    for provider_name in PROVIDER_ORDER:
+        if any(item["provider"] == provider_name for item in successful_provider_data):
+            return provider_name
+    return None
+
+
+def _build_source_meta(
+    requested_provider: str,
+    provider_results: dict,
+) -> dict:
+    """根据 provider 查询结果构造来源元信息。"""
+
+    successful = [
+        result["provider"]
+        for result in provider_results.values()
+        if result["status"] == "success"
+    ]
+    failed = [
+        result["provider"]
+        for result in provider_results.values()
+        if result["status"] == "error"
+    ]
+    return {
+        "query_mode": requested_provider,
+        "successful_providers": successful,
+        "failed_providers": failed,
+        "summary_provider_policy": "open-meteo-first",
+    }
+
+
+def _ensure_any_provider_success(provider_results: dict) -> None:
+    """确保至少有一个 provider 查询成功，否则抛出错误。"""
+
+    if any(result["status"] == "success" for result in provider_results.values()):
+        return
+
+    errors = {
+        provider_name: result["error"]
+        for provider_name, result in provider_results.items()
+        if result["status"] == "error"
+    }
+    raise MCPError(
+        MCPError.EXTERNAL_API_ERROR,
+        "所有天气 provider 查询均失败。",
+        {"provider_errors": errors},
+    )
+
+
+def _build_location(
+    lat: float,
+    lon: float,
+    location_name: str | None,
+    timezone: str | None,
+    successful_provider_data: list[dict],
+) -> dict:
+    """构造聚合结果的位置对象。"""
+
+    resolved_name = location_name
+    resolved_timezone = timezone
+    for item in successful_provider_data:
+        provider_location = item["data"].get("location", {})
+        if resolved_name is None and provider_location.get("name") is not None:
+            resolved_name = provider_location.get("name")
+        if resolved_timezone is None and provider_location.get("timezone") is not None:
+            resolved_timezone = provider_location.get("timezone")
+    return build_location_payload(resolved_name, lat, lon, resolved_timezone)

--- a/src/qweather_interaction.py
+++ b/src/qweather_interaction.py
@@ -177,6 +177,21 @@ def qweather_get_weather_by_coord_in_ten_days(
     api = f"https://{host}/v7/weather/10d?location={lon},{lat}"
     return fetch_gzipped_json(api, api_token, jwt_token=jwt_token)
 
+
+def qweather_get_weather_by_coord_in_twenty_four_hours(
+    lon: float,
+    lat: float,
+    api_token: str | None,
+    *,
+    api_host: str | None = None,
+    jwt_token: str | None = None,
+) -> dict | None:
+    """根据经纬度获取 24 小时逐小时预报。"""
+
+    host = (api_host or _get_api_host_or_fail("api.qweather.com")).strip().rstrip("/")
+    api = f"https://{host}/v7/weather/24h?location={lon},{lat}"
+    return fetch_gzipped_json(api, api_token, jwt_token=jwt_token)
+
 def qweather_get_weather_by_name(
     city: str,
     api_token: str | None,

--- a/tests/test_structured_errors.py
+++ b/tests/test_structured_errors.py
@@ -88,37 +88,44 @@ def test_missing_api_key_error():
     assert "QWEATHER_API_KEY" in error.message
 
 
-@patch('src.functions.weather.impl.qweather_get_weather_by_name')
-@patch.dict('os.environ', {'QWEATHER_API_KEY': 'test_key', 'QWEATHER_API_HOST': 'test.host'}, clear=True)
-def test_weather_api_error_handling(mock_qweather):
+@patch('src.functions.weather.impl.get_aggregated_weather_by_name')
+def test_weather_api_error_handling(mock_service):
     """Test that weather API errors are properly handled with MCPError."""
-    mock_qweather.side_effect = ValueError("QWeather 请求失败: Connection timeout")
+    mock_service.side_effect = MCPError(
+        MCPError.EXTERNAL_API_ERROR,
+        "provider failed",
+        {"place_name": "Test City"},
+    )
     
     with pytest.raises(MCPError) as exc_info:
         get_weather_by_name.fn("Test City")
     
     error = exc_info.value
     assert error.code == MCPError.EXTERNAL_API_ERROR
-    assert "Test City" in error.message
+    assert error.details["place_name"] == "Test City"
 
 
 @patch('src.retry.time.sleep')  # Mock sleep to speed up test
-@patch('src.functions.weather.impl.qweather_get_weather_by_name')
-@patch.dict('os.environ', {'QWEATHER_API_KEY': 'test_key', 'QWEATHER_API_HOST': 'test.host'}, clear=True)
-def test_weather_retry_logic(mock_qweather, mock_sleep):
+@patch('src.functions.weather.impl.get_aggregated_weather_by_name')
+def test_weather_retry_logic(mock_service, mock_sleep):
     """Test that weather functions retry on network errors and eventually succeed."""
     # First two calls fail with network error, third succeeds
-    mock_qweather.side_effect = [
+    mock_service.side_effect = [
         ConnectionError("Network timeout"),
         ConnectionError("Network timeout"), 
-        {"weather": "sunny"}
+        {
+            "location": {"name": "Test City", "lat": 0.0, "lon": 0.0, "timezone": None},
+            "summary": {"current": {"temperature_c": 20.0}, "daily": [], "hourly": []},
+            "providers": {},
+            "source": {"query_mode": "all", "successful_providers": ["open-meteo"], "failed_providers": []},
+        }
     ]
     
     result = get_weather_by_name.fn("Test City")
     
     # Should have been called 3 times (initial + 2 retries)
-    assert mock_qweather.call_count == 3
+    assert mock_service.call_count == 3
     # Should have slept twice (between retries)
     assert mock_sleep.call_count == 2
     # Should return success on third try
-    assert result["data"]["weather"] == "sunny"
+    assert result["data"]["summary"]["current"]["temperature_c"] == 20.0

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -11,25 +11,44 @@ def test_get_weather_by_name_no_api_key():
             
         with pytest.raises(MCPError, match="QWEATHER_API_KEY|QWEATHER_JWT_TOKEN"):
             # Use .fn to call the underlying function
-            get_weather_by_name.fn("Beijing")
+            from src.functions.weather.impl import _get_qweather_auth_from_env
+            _get_qweather_auth_from_env()
 
 def test_get_weather_by_name_success():
-    with patch.dict(os.environ, {"QWEATHER_API_KEY": "fake_key"}), \
-         patch("src.functions.weather.impl.qweather_get_weather_by_name") as mock_api:
-        mock_api.return_value = {"weather": "sunny"}
+    aggregated_result = {
+        "location": {"name": "Beijing", "lat": 39.9, "lon": 116.4, "timezone": "Asia/Shanghai"},
+        "summary": {
+            "current": {"temperature_c": 20.0, "cloud_cover_percent": 50.0},
+            "daily": [],
+            "hourly": [{"time": "2026-06-15T10:00:00+08:00", "cloud_cover_percent": 55.0}],
+        },
+        "providers": {},
+        "source": {"query_mode": "all", "successful_providers": ["open-meteo"], "failed_providers": []},
+    }
+    with patch("src.functions.weather.impl.get_aggregated_weather_by_name") as mock_service:
+        mock_service.return_value = aggregated_result
         result = get_weather_by_name.fn("Beijing")
         
         assert "data" in result
-        assert result["data"] == {"weather": "sunny"}
+        assert result["data"] == aggregated_result
         assert result["_meta"]["status"] == "success"
-        mock_api.assert_called_with("Beijing", "fake_key", api_host=None, jwt_token=None)
+        mock_service.assert_called_with("Beijing", provider="all")
 
 def test_get_weather_by_position_success():
-    with patch.dict(os.environ, {"QWEATHER_API_KEY": "fake_key"}), \
-         patch("src.functions.weather.impl.qweather_get_weather_by_position") as mock_api:
-        mock_api.return_value = {"temp": 20}
+    aggregated_result = {
+        "location": {"name": None, "lat": 40.0, "lon": 116.0, "timezone": "Asia/Shanghai"},
+        "summary": {
+            "current": {"temperature_c": 20.0, "cloud_cover_percent": 40.0},
+            "daily": [],
+            "hourly": [{"time": "2026-06-15T10:00:00+08:00", "cloud_cover_percent": 42.0}],
+        },
+        "providers": {},
+        "source": {"query_mode": "all", "successful_providers": ["open-meteo"], "failed_providers": []},
+    }
+    with patch("src.functions.weather.impl.get_aggregated_weather_by_position") as mock_service:
+        mock_service.return_value = aggregated_result
         result = get_weather_by_position.fn(40.0, 116.0)
         
         assert "data" in result
-        assert result["data"] == {"temp": 20}
-        mock_api.assert_called_with(40.0, 116.0, "fake_key", api_host=None, jwt_token=None)
+        assert result["data"] == aggregated_result
+        mock_service.assert_called_with(40.0, 116.0, provider="all")

--- a/tests/test_weather_service.py
+++ b/tests/test_weather_service.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+from src.functions.weather.service import get_aggregated_weather_by_position
+
+
+def test_aggregated_weather_by_position_uses_open_meteo_hourly_first():
+    open_meteo_result = {
+        "status": "success",
+        "provider": "open-meteo",
+        "data": {
+            "location": {"name": "Beijing", "lat": 39.9, "lon": 116.4, "timezone": "Asia/Shanghai"},
+            "current": {"temperature_c": 25.0, "cloud_cover_percent": 60.0},
+            "daily": [{"date": "2026-06-15", "cloud_cover_percent": 65.0}],
+            "hourly": [{"time": "2026-06-15T10:00:00+08:00", "cloud_cover_percent": 55.0}],
+        },
+    }
+    wttr_result = {
+        "status": "success",
+        "provider": "wttr",
+        "data": {
+            "location": {"name": "Beijing", "lat": 39.9, "lon": 116.4, "timezone": None},
+            "current": {"temperature_c": 24.0, "cloud_cover_percent": 45.0},
+            "daily": [{"date": "2026-06-15", "cloud_cover_percent": 50.0}],
+            "hourly": [{"time": "2026-06-15T10:00:00+08:00", "cloud_cover_percent": 40.0}],
+        },
+    }
+
+    with patch("src.functions.weather.service.open_meteo.get_weather_by_position", return_value=open_meteo_result), \
+         patch("src.functions.weather.service.qweather.get_weather_by_position", side_effect=Exception("should not be called")), \
+         patch("src.functions.weather.service.wttr.get_weather_by_position", return_value=wttr_result):
+        result = get_aggregated_weather_by_position(39.9, 116.4, provider="all", location_name="Beijing")
+
+    assert result["summary"]["current"]["temperature_c"] == 25.0
+    assert result["summary"]["hourly"][0]["cloud_cover_percent"] == 55.0
+    assert result["source"]["successful_providers"] == ["open-meteo", "wttr"]
+
+
+def test_aggregated_weather_by_position_keeps_partial_provider_failures():
+    open_meteo_result = {
+        "status": "success",
+        "provider": "open-meteo",
+        "data": {
+            "location": {"name": None, "lat": 40.0, "lon": 116.0, "timezone": "Asia/Shanghai"},
+            "current": {"temperature_c": 22.0, "cloud_cover_percent": 35.0},
+            "daily": [],
+            "hourly": [],
+        },
+    }
+
+    with patch("src.functions.weather.service.open_meteo.get_weather_by_position", return_value=open_meteo_result), \
+         patch("src.functions.weather.service.qweather.get_weather_by_position", side_effect=Exception("qweather down")), \
+         patch("src.functions.weather.service.wttr.get_weather_by_position", side_effect=Exception("wttr down")):
+        result = get_aggregated_weather_by_position(40.0, 116.0, provider="all")
+
+    assert result["summary"]["current"]["cloud_cover_percent"] == 35.0
+    assert set(result["source"]["failed_providers"]) == {"qweather", "wttr"}

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,7 @@ requires-python = ">=3.13"
 [[package]]
 name = "affine"
 version = "2.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/69/98/d2f0bb06385069e799fc7d2870d9e078cfa0fa396dc8a2b81227d0da08b9/affine-2.4.0.tar.gz", hash = "sha256:a24d818d6a836c131976d22f8c27b8d3ca32d0af64c1d8d29deb7bafa4da1eea", size = 17132, upload-time = "2023-01-19T23:44:30.696Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0b/f7/85273299ab57117850cc0a936c64151171fac4da49bc6fba0dad984a7c5f/affine-2.4.0-py3-none-any.whl", hash = "sha256:8a3df80e2b2378aef598a83c1392efd47967afec4242021a0b06b4c7cbc61a92", size = 15662, upload-time = "2023-01-19T23:44:28.833Z" },
@@ -14,7 +14,7 @@ wheels = [
 [[package]]
 name = "aiobotocore"
 version = "2.26.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aioitertools" },
@@ -32,7 +32,7 @@ wheels = [
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
@@ -41,7 +41,7 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.13.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
@@ -109,7 +109,7 @@ wheels = [
 [[package]]
 name = "aioitertools"
 version = "0.13.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
@@ -118,7 +118,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "frozenlist" },
 ]
@@ -130,7 +130,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -139,7 +139,7 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.11.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "idna" },
     { name = "sniffio" },
@@ -152,7 +152,7 @@ wheels = [
 [[package]]
 name = "appnope"
 version = "0.1.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
@@ -161,7 +161,7 @@ wheels = [
 [[package]]
 name = "asdf"
 version = "5.1.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "asdf-standard" },
     { name = "asdf-transform-schemas" },
@@ -180,7 +180,7 @@ wheels = [
 [[package]]
 name = "asdf-astropy"
 version = "0.9.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "asdf" },
     { name = "asdf-coordinates-schemas" },
@@ -198,7 +198,7 @@ wheels = [
 [[package]]
 name = "asdf-coordinates-schemas"
 version = "0.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "asdf" },
     { name = "asdf-standard" },
@@ -211,7 +211,7 @@ wheels = [
 [[package]]
 name = "asdf-standard"
 version = "1.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/34/09/95ba03c85b044c717543d4aeb0f50b5c96aaeda7390a527cbb155a7e0550/asdf_standard-1.4.0.tar.gz", hash = "sha256:0c5f121d0db87cb7780d61a087f392c5104ce208016cfb2a130c9cea912cfddc", size = 275426, upload-time = "2025-08-27T20:36:37.317Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b3/b6/2bfee05505425931adaec51ad2aa676d30abcb7c4f306f8541e2528e5abc/asdf_standard-1.4.0-py3-none-any.whl", hash = "sha256:884e83e113a9e6802047d51db113bc6ffcdf60451f74ce17ea80579d35388cf7", size = 96781, upload-time = "2025-08-27T20:36:35.428Z" },
@@ -220,7 +220,7 @@ wheels = [
 [[package]]
 name = "asdf-transform-schemas"
 version = "0.6.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "asdf-standard" },
 ]
@@ -232,7 +232,7 @@ wheels = [
 [[package]]
 name = "astropy"
 version = "7.1.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "astropy-iers-data" },
     { name = "numpy" },
@@ -290,7 +290,7 @@ all = [
 [[package]]
 name = "astropy-iers-data"
 version = "0.2025.11.10.0.38.31"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a6/56/bbcef87b43e7ce4a23555d17aec0ff6d19a0a1880ff7e21099ee022ef004/astropy_iers_data-0.2025.11.10.0.38.31.tar.gz", hash = "sha256:487dc974b9a5114ac75ff4fd96244e8fa7d07e1504092f7c2b8138c2b9c842e9", size = 1913161, upload-time = "2025-11-10T00:39:14.899Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d3/9d/51b958a9f8474f04462923550641ccbef9a50566a63c87d691bec443a7d0/astropy_iers_data-0.2025.11.10.0.38.31-py3-none-any.whl", hash = "sha256:620155a3f04d7c96e7f4aaa498dc4571e15449f23963574106d29d8959d4c66f", size = 1969542, upload-time = "2025-11-10T00:39:12.824Z" },
@@ -299,7 +299,7 @@ wheels = [
 [[package]]
 name = "astroquery"
 version = "0.4.11"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "astropy" },
     { name = "beautifulsoup4" },
@@ -317,7 +317,7 @@ wheels = [
 [[package]]
 name = "asttokens"
 version = "3.0.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
@@ -326,7 +326,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "25.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
@@ -335,7 +335,7 @@ wheels = [
 [[package]]
 name = "authlib"
 version = "1.6.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
@@ -347,7 +347,7 @@ wheels = [
 [[package]]
 name = "beartype"
 version = "0.22.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a6/09/9003e5662691056e0e8b2e6f57c799e71875fac0be0e785d8cb11557cd2a/beartype-0.22.5.tar.gz", hash = "sha256:516a9096cc77103c96153474fa35c3ebcd9d36bd2ec8d0e3a43307ced0fa6341", size = 1586256, upload-time = "2025-11-01T05:49:20.771Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f7/f6/073d19f7b571c08327fbba3f8e011578da67ab62a11f98911274ff80653f/beartype-0.22.5-py3-none-any.whl", hash = "sha256:d9743dd7cd6d193696eaa1e025f8a70fb09761c154675679ff236e61952dfba0", size = 1321700, upload-time = "2025-11-01T05:49:18.436Z" },
@@ -356,7 +356,7 @@ wheels = [
 [[package]]
 name = "beautifulsoup4"
 version = "4.14.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
@@ -369,7 +369,7 @@ wheels = [
 [[package]]
 name = "bleach"
 version = "6.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
@@ -381,7 +381,7 @@ wheels = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -390,7 +390,7 @@ wheels = [
 [[package]]
 name = "botocore"
 version = "1.41.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
@@ -404,7 +404,7 @@ wheels = [
 [[package]]
 name = "bottleneck"
 version = "1.6.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -443,7 +443,7 @@ wheels = [
 [[package]]
 name = "bqplot"
 version = "0.12.45"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "ipywidgets" },
     { name = "numpy" },
@@ -459,7 +459,7 @@ wheels = [
 [[package]]
 name = "branca"
 version = "0.8.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "jinja2" },
 ]
@@ -471,7 +471,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "6.2.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz", hash = "sha256:3f391e4bd8f8bf0931169baf7456cc822705f4e2a31f840d218f445b9a854201", size = 31325, upload-time = "2025-10-12T14:55:30.139Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl", hash = "sha256:09868944b6dde876dfd44e1d47e18484541eaf12f26f29b7af91b26cc892d701", size = 11280, upload-time = "2025-10-12T14:55:28.382Z" },
@@ -480,7 +480,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2025.11.12"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
@@ -489,7 +489,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "2.0.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
@@ -534,7 +534,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -587,7 +587,7 @@ wheels = [
 [[package]]
 name = "click-plugins"
 version = "1.1.1.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "click" },
 ]
@@ -599,7 +599,7 @@ wheels = [
 [[package]]
 name = "cligj"
 version = "0.7.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "click" },
 ]
@@ -611,7 +611,7 @@ wheels = [
 [[package]]
 name = "cloudpickle"
 version = "3.1.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
@@ -620,7 +620,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -629,7 +629,7 @@ wheels = [
 [[package]]
 name = "comm"
 version = "0.2.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
@@ -638,7 +638,7 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -693,7 +693,7 @@ wheels = [
 [[package]]
 name = "cryptography"
 version = "46.0.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
@@ -749,7 +749,7 @@ wheels = [
 [[package]]
 name = "cycler"
 version = "0.12.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30" },
@@ -758,7 +758,7 @@ wheels = [
 [[package]]
 name = "cyclopts"
 version = "4.2.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
@@ -773,7 +773,7 @@ wheels = [
 [[package]]
 name = "dask"
 version = "2025.12.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
@@ -796,7 +796,7 @@ array = [
 [[package]]
 name = "debugpy"
 version = "1.8.19"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/73/75/9e12d4d42349b817cd545b89247696c67917aab907012ae5b64bbfea3199/debugpy-1.8.19.tar.gz", hash = "sha256:eea7e5987445ab0b5ed258093722d5ecb8bb72217c5c9b1e21f64efe23ddebdb", size = 1644590, upload-time = "2025-12-15T21:53:28.044Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/71/3d/388035a31a59c26f1ecc8d86af607d0c42e20ef80074147cd07b180c4349/debugpy-1.8.19-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:91e35db2672a0abaf325f4868fcac9c1674a0d9ad9bb8a8c849c03a5ebba3e6d", size = 2538859, upload-time = "2025-12-15T21:53:50.478Z" },
@@ -813,7 +813,7 @@ wheels = [
 [[package]]
 name = "decorator"
 version = "5.2.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
@@ -822,7 +822,7 @@ wheels = [
 [[package]]
 name = "diskcache"
 version = "5.6.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19" },
@@ -831,7 +831,7 @@ wheels = [
 [[package]]
 name = "dnspython"
 version = "2.8.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
@@ -840,7 +840,7 @@ wheels = [
 [[package]]
 name = "docstring-parser"
 version = "0.17.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
@@ -849,7 +849,7 @@ wheels = [
 [[package]]
 name = "docutils"
 version = "0.22.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d9/02/111134bfeb6e6c7ac4c74594e39a59f6c0195dc4846afbeac3cba60f1927/docutils-0.22.3.tar.gz", hash = "sha256:21486ae730e4ca9f622677b1412b879af1791efcfba517e4c6f60be543fc8cdd", size = 2290153, upload-time = "2025-11-06T02:35:55.655Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/11/a8/c6a4b901d17399c77cd81fb001ce8961e9f5e04d3daf27e8925cb012e163/docutils-0.22.3-py3-none-any.whl", hash = "sha256:bd772e4aca73aff037958d44f2be5229ded4c09927fcf8690c577b66234d6ceb", size = 633032, upload-time = "2025-11-06T02:35:52.391Z" },
@@ -858,7 +858,7 @@ wheels = [
 [[package]]
 name = "email-validator"
 version = "2.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "dnspython" },
     { name = "idna" },
@@ -871,7 +871,7 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
@@ -880,7 +880,7 @@ wheels = [
 [[package]]
 name = "executing"
 version = "2.2.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
@@ -889,7 +889,7 @@ wheels = [
 [[package]]
 name = "fastmcp"
 version = "2.13.0.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
@@ -914,7 +914,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "3.1.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
@@ -931,7 +931,7 @@ wheels = [
 [[package]]
 name = "flask-cors"
 version = "6.0.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
@@ -944,7 +944,7 @@ wheels = [
 [[package]]
 name = "folium"
 version = "0.20.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "branca" },
     { name = "jinja2" },
@@ -960,7 +960,7 @@ wheels = [
 [[package]]
 name = "fonttools"
 version = "4.60.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/4b/42/97a13e47a1e51a5a7142475bbcf5107fe3a68fc34aef331c897d5fb98ad0/fonttools-4.60.1.tar.gz", hash = "sha256:ef00af0439ebfee806b25f24c8f92109157ff3fac5731dc7867957812e87b8d9", size = 3559823, upload-time = "2025-09-29T21:13:27.129Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7c/5b/cdd2c612277b7ac7ec8c0c9bc41812c43dc7b2d5f2b0897e15fdf5a1f915/fonttools-4.60.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6f68576bb4bbf6060c7ab047b1574a1ebe5c50a17de62830079967b211059ebb", size = 2825777, upload-time = "2025-09-29T21:12:01.22Z" },
@@ -993,7 +993,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.8.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
@@ -1066,7 +1066,7 @@ wheels = [
 [[package]]
 name = "fsspec"
 version = "2025.12.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b6/27/954057b0d1f53f086f681755207dda6de6c660ce133c829158e8e8fe7895/fsspec-2025.12.0.tar.gz", hash = "sha256:c505de011584597b1060ff778bb664c1bc022e87921b0e4f10cc9c44f9635973", size = 309748, upload-time = "2025-12-03T15:23:42.687Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl", hash = "sha256:8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b", size = 201422, upload-time = "2025-12-03T15:23:41.434Z" },
@@ -1080,7 +1080,7 @@ http = [
 [[package]]
 name = "gast"
 version = "0.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/83/4a/07c7e59cef23fb147454663c3271c21da68ba2ab141427c20548ae5a8a4d/gast-0.4.0.tar.gz", hash = "sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1", size = 13804, upload-time = "2020-08-07T21:45:23.526Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b6/48/583c032b79ae5b3daa02225a675aeb673e58d2cb698e78510feceb11958c/gast-0.4.0-py3-none-any.whl", hash = "sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4", size = 9824, upload-time = "2020-08-07T21:45:21.32Z" },
@@ -1089,7 +1089,7 @@ wheels = [
 [[package]]
 name = "geographiclib"
 version = "2.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/df/78/4892343230a9d29faa1364564e525307a37e54ad776ea62c12129dbba704/geographiclib-2.1.tar.gz", hash = "sha256:6a6545e6262d0ed3522e13c515713718797e37ed8c672c31ad7b249f372ef108", size = 37004, upload-time = "2025-08-21T21:34:26Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/31/b3/802576f2ea5dcb48501bb162e4c7b7b3ca5654a42b2c968ef98a797a4c79/geographiclib-2.1-py3-none-any.whl", hash = "sha256:e2a873b9b9e7fc38721ad73d5f4e6c9ed140d428a339970f505c07056997d40b", size = 40740, upload-time = "2025-08-21T21:34:24.955Z" },
@@ -1098,7 +1098,7 @@ wheels = [
 [[package]]
 name = "geopandas"
 version = "1.1.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
@@ -1115,7 +1115,7 @@ wheels = [
 [[package]]
 name = "geopy"
 version = "2.4.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "geographiclib" },
 ]
@@ -1127,7 +1127,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -1136,7 +1136,7 @@ wheels = [
 [[package]]
 name = "h5py"
 version = "3.15.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -1163,7 +1163,7 @@ wheels = [
 [[package]]
 name = "html5lib"
 version = "1.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "six" },
     { name = "webencodings" },
@@ -1176,7 +1176,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -1189,7 +1189,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -1204,7 +1204,7 @@ wheels = [
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
@@ -1213,7 +1213,7 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.11"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
@@ -1222,7 +1222,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -1231,7 +1231,7 @@ wheels = [
 [[package]]
 name = "ipydatagrid"
 version = "1.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "bqplot" },
     { name = "ipywidgets" },
@@ -1246,7 +1246,7 @@ wheels = [
 [[package]]
 name = "ipykernel"
 version = "7.1.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
@@ -1270,7 +1270,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "9.8.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "decorator" },
@@ -1291,7 +1291,7 @@ wheels = [
 [[package]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "pygments" },
 ]
@@ -1303,7 +1303,7 @@ wheels = [
 [[package]]
 name = "ipywidgets"
 version = "8.1.8"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "comm" },
     { name = "ipython" },
@@ -1319,7 +1319,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -1328,7 +1328,7 @@ wheels = [
 [[package]]
 name = "jaraco-classes"
 version = "3.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -1340,7 +1340,7 @@ wheels = [
 [[package]]
 name = "jaraco-context"
 version = "6.0.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload-time = "2024-08-20T03:39:25.966Z" },
@@ -1349,7 +1349,7 @@ wheels = [
 [[package]]
 name = "jaraco-functools"
 version = "4.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -1361,7 +1361,7 @@ wheels = [
 [[package]]
 name = "jedi"
 version = "0.19.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "parso" },
 ]
@@ -1373,7 +1373,7 @@ wheels = [
 [[package]]
 name = "jeepney"
 version = "0.9.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
@@ -1382,7 +1382,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -1394,7 +1394,7 @@ wheels = [
 [[package]]
 name = "jmespath"
 version = "1.0.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
@@ -1403,7 +1403,7 @@ wheels = [
 [[package]]
 name = "joblib"
 version = "1.5.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
@@ -1412,7 +1412,7 @@ wheels = [
 [[package]]
 name = "jplephem"
 version = "2.23"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -1424,7 +1424,7 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.25.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
@@ -1439,7 +1439,7 @@ wheels = [
 [[package]]
 name = "jsonschema-path"
 version = "0.3.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "pathable" },
     { name = "pyyaml" },
@@ -1454,7 +1454,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -1466,7 +1466,7 @@ wheels = [
 [[package]]
 name = "jupyter-client"
 version = "8.7.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "jupyter-core" },
     { name = "python-dateutil" },
@@ -1482,7 +1482,7 @@ wheels = [
 [[package]]
 name = "jupyter-core"
 version = "5.9.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "platformdirs" },
     { name = "traitlets" },
@@ -1495,7 +1495,7 @@ wheels = [
 [[package]]
 name = "jupyterlab-widgets"
 version = "3.0.16"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
@@ -1504,7 +1504,7 @@ wheels = [
 [[package]]
 name = "keyring"
 version = "25.6.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
@@ -1521,7 +1521,7 @@ wheels = [
 [[package]]
 name = "kiwisolver"
 version = "1.4.9"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/5c/3c/85844f1b0feb11ee581ac23fe5fce65cd049a200c1446708cc1b7f922875/kiwisolver-1.4.9.tar.gz", hash = "sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d", size = 97564, upload-time = "2025-08-10T21:27:49.279Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/31/c1/c2686cda909742ab66c7388e9a1a8521a59eb89f8bcfbee28fc980d07e24/kiwisolver-1.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5d0432ccf1c7ab14f9949eec60c5d1f924f17c037e9f8b33352fa05799359b8", size = 123681, upload-time = "2025-08-10T21:26:26.725Z" },
@@ -1580,7 +1580,7 @@ wheels = [
 [[package]]
 name = "locket"
 version = "1.0.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
@@ -1589,7 +1589,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.0.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -1601,7 +1601,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
@@ -1653,7 +1653,7 @@ wheels = [
 [[package]]
 name = "matplotlib"
 version = "3.10.7"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "contourpy" },
     { name = "cycler" },
@@ -1700,7 +1700,7 @@ wheels = [
 [[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
@@ -1712,7 +1712,7 @@ wheels = [
 [[package]]
 name = "mcp"
 version = "1.21.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
@@ -1734,7 +1734,7 @@ wheels = [
 
 [[package]]
 name = "mcp-stargazing"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy", extra = ["all"] },
@@ -1744,6 +1744,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pytz" },
     { name = "rasterio" },
+    { name = "requests" },
     { name = "stargazing-place-finder" },
     { name = "tzlocal" },
 ]
@@ -1763,6 +1764,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24,<2.4" },
     { name = "pytz" },
     { name = "rasterio" },
+    { name = "requests" },
     { name = "stargazing-place-finder", specifier = "==0.6.0" },
     { name = "tzlocal" },
 ]
@@ -1776,7 +1778,7 @@ dev = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -1785,7 +1787,7 @@ wheels = [
 [[package]]
 name = "more-itertools"
 version = "10.8.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
@@ -1794,7 +1796,7 @@ wheels = [
 [[package]]
 name = "mpmath"
 version = "1.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
@@ -1803,7 +1805,7 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.7.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/80/1e/5492c365f222f907de1039b91f922b93fa4f764c713ee858d235495d8f50/multidict-6.7.0.tar.gz", hash = "sha256:c6e99d9a65ca282e578dfea819cfa9c0a62b2499d8677392e09feaf305e9e6f5", size = 101834, upload-time = "2025-10-06T14:52:30.657Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d2/86/33272a544eeb36d66e4d9a920602d1a2f57d4ebea4ef3cdfe5a912574c95/multidict-6.7.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bee7c0588aa0076ce77c0ea5d19a68d76ad81fcd9fe8501003b9a24f9d4000f6", size = 76135, upload-time = "2025-10-06T14:49:54.26Z" },
@@ -1884,7 +1886,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "2.22.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
@@ -1893,7 +1895,7 @@ wheels = [
 [[package]]
 name = "nest-asyncio"
 version = "1.6.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
@@ -1902,7 +1904,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
@@ -1911,7 +1913,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.3.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b5/f4/098d2270d52b41f1bd7db9fc288aaa0400cb48c2a3e2af6fa365d9720947/numpy-2.3.4.tar.gz", hash = "sha256:a7d018bfedb375a8d979ac758b120ba846a7fe764911a64465fd87b8729f4a6a", size = 20582187, upload-time = "2025-10-15T16:18:11.77Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/57/7e/b72610cc91edf138bc588df5150957a4937221ca6058b825b4725c27be62/numpy-2.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c090d4860032b857d94144d1a9976b8e36709e40386db289aaf6672de2a81966", size = 20950335, upload-time = "2025-10-15T16:16:10.304Z" },
@@ -1963,7 +1965,7 @@ wheels = [
 [[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1975,7 +1977,7 @@ wheels = [
 [[package]]
 name = "osmnx"
 version = "2.0.6"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "geopandas" },
     { name = "networkx" },
@@ -1992,7 +1994,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "25.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
@@ -2001,7 +2003,7 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.3.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
@@ -2041,7 +2043,7 @@ wheels = [
 [[package]]
 name = "parso"
 version = "0.8.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
@@ -2050,7 +2052,7 @@ wheels = [
 [[package]]
 name = "partd"
 version = "1.4.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "locket" },
     { name = "toolz" },
@@ -2063,7 +2065,7 @@ wheels = [
 [[package]]
 name = "pathable"
 version = "0.4.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
@@ -2072,7 +2074,7 @@ wheels = [
 [[package]]
 name = "pathvalidate"
 version = "3.3.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
@@ -2081,7 +2083,7 @@ wheels = [
 [[package]]
 name = "pexpect"
 version = "4.9.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "ptyprocess" },
 ]
@@ -2093,7 +2095,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "12.0.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/5a/b0/cace85a1b0c9775a9f8f5d5423c8261c858760e2466c79b2dd184638b056/pillow-12.0.0.tar.gz", hash = "sha256:87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353", size = 47008828, upload-time = "2025-10-15T18:24:14.008Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/62/f2/de993bb2d21b33a98d031ecf6a978e4b61da207bef02f7b43093774c480d/pillow-12.0.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0869154a2d0546545cde61d1789a6524319fc1897d9ee31218eae7a60ccc5643", size = 4045493, upload-time = "2025-10-15T18:22:25.758Z" },
@@ -2151,7 +2153,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.5.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
@@ -2160,7 +2162,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -2169,7 +2171,7 @@ wheels = [
 [[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -2181,7 +2183,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.4.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/bf/df/6d9c1b6ac12b003837dde8a10231a7344512186e87b36e855bef32241942/propcache-0.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:43eedf29202c08550aac1d14e0ee619b0430aaef78f85864c1a892294fbc28cf", size = 77750, upload-time = "2025-10-08T19:47:07.648Z" },
@@ -2250,7 +2252,7 @@ wheels = [
 [[package]]
 name = "psutil"
 version = "7.2.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/be/7c/31d1c3ceb1260301f87565f50689dc6da3db427ece1e1e012af22abca54e/psutil-7.2.0.tar.gz", hash = "sha256:2e4f8e1552f77d14dc96fb0f6240c5b34a37081c0889f0853b3b29a496e5ef64", size = 489863, upload-time = "2025-12-23T20:26:24.616Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a8/8e/b35aae6ed19bc4e2286cac4832e4d522fcf00571867b0a85a3f77ef96a80/psutil-7.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c31e927555539132a00380c971816ea43d089bf4bd5f3e918ed8c16776d68474", size = 129593, upload-time = "2025-12-23T20:26:28.019Z" },
@@ -2278,7 +2280,7 @@ wheels = [
 [[package]]
 name = "psycopg2-binary"
 version = "2.9.11"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ac/6c/8767aaa597ba424643dc87348c6f1754dd9f48e80fdc1b9f7ca5c3a7c213/psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c", size = 379620, upload-time = "2025-10-10T11:14:48.041Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ff/a8/a2709681b3ac11b0b1786def10006b8995125ba268c9a54bea6f5ae8bd3e/psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c", size = 3756572, upload-time = "2025-10-10T11:12:32.873Z" },
@@ -2308,7 +2310,7 @@ wheels = [
 [[package]]
 name = "ptyprocess"
 version = "0.7.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
@@ -2317,7 +2319,7 @@ wheels = [
 [[package]]
 name = "pure-eval"
 version = "0.2.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
@@ -2326,7 +2328,7 @@ wheels = [
 [[package]]
 name = "py-key-value-aio"
 version = "0.2.8"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "py-key-value-shared" },
@@ -2351,7 +2353,7 @@ memory = [
 [[package]]
 name = "py-key-value-shared"
 version = "0.2.8"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "typing-extensions" },
@@ -2364,7 +2366,7 @@ wheels = [
 [[package]]
 name = "py2vega"
 version = "0.6.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "gast" },
 ]
@@ -2376,7 +2378,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "22.0.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/30/53/04a7fdc63e6056116c9ddc8b43bc28c12cdd181b85cbeadb79278475f3ae/pyarrow-22.0.0.tar.gz", hash = "sha256:3d600dc583260d845c7d8a6db540339dd883081925da2bd1c5cb808f720b3cd9", size = 1151151, upload-time = "2025-10-24T12:30:00.762Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a6/d6/d0fac16a2963002fc22c8fa75180a838737203d558f0ed3b564c4a54eef5/pyarrow-22.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e6e95176209257803a8b3d0394f21604e796dadb643d2f7ca21b66c9c0b30c9a", size = 34204629, upload-time = "2025-10-24T10:06:20.274Z" },
@@ -2412,7 +2414,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "2.23"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
@@ -2421,7 +2423,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.13.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
@@ -2441,7 +2443,7 @@ email = [
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -2497,7 +2499,7 @@ wheels = [
 [[package]]
 name = "pydantic-settings"
 version = "2.12.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -2511,7 +2513,7 @@ wheels = [
 [[package]]
 name = "pyerfa"
 version = "2.0.1.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -2529,7 +2531,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.19.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
@@ -2538,7 +2540,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.10.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
@@ -2552,7 +2554,7 @@ crypto = [
 [[package]]
 name = "pyogrio"
 version = "0.11.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "numpy" },
@@ -2571,7 +2573,7 @@ wheels = [
 [[package]]
 name = "pyparsing"
 version = "3.2.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
@@ -2580,7 +2582,7 @@ wheels = [
 [[package]]
 name = "pyperclip"
 version = "1.11.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
@@ -2589,7 +2591,7 @@ wheels = [
 [[package]]
 name = "pyproj"
 version = "3.7.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "certifi" },
 ]
@@ -2636,7 +2638,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "9.0.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
@@ -2652,7 +2654,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "1.3.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -2664,7 +2666,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -2676,7 +2678,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.2.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
@@ -2685,7 +2687,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.20"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
@@ -2694,7 +2696,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2025.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
@@ -2703,7 +2705,7 @@ wheels = [
 [[package]]
 name = "pyvo"
 version = "1.7.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "astropy" },
     { name = "requests" },
@@ -2716,7 +2718,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "311"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
@@ -2729,7 +2731,7 @@ wheels = [
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
@@ -2738,7 +2740,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
@@ -2774,7 +2776,7 @@ wheels = [
 [[package]]
 name = "pyzmq"
 version = "27.1.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
@@ -2817,7 +2819,7 @@ wheels = [
 [[package]]
 name = "rasterio"
 version = "1.4.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "affine" },
     { name = "attrs" },
@@ -2839,7 +2841,7 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.36.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
@@ -2852,7 +2854,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.32.5"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -2867,7 +2869,7 @@ wheels = [
 [[package]]
 name = "rich"
 version = "14.2.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -2880,7 +2882,7 @@ wheels = [
 [[package]]
 name = "rich-rst"
 version = "1.3.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "rich" },
@@ -2893,7 +2895,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "0.28.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/48/dc/95f074d43452b3ef5d06276696ece4b3b5d696e7c9ad7173c54b1390cd70/rpds_py-0.28.0.tar.gz", hash = "sha256:abd4df20485a0983e2ca334a216249b6186d6e3c1627e106651943dbdb791aea", size = 27419, upload-time = "2025-10-22T22:24:29.327Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d3/03/ce566d92611dfac0085c2f4b048cd53ed7c274a5c05974b882a908d540a2/rpds_py-0.28.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e9e184408a0297086f880556b6168fa927d677716f83d3472ea333b42171ee3b", size = 366235, upload-time = "2025-10-22T22:22:28.397Z" },
@@ -2959,7 +2961,7 @@ wheels = [
 [[package]]
 name = "s3fs"
 version = "2025.12.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
@@ -2973,7 +2975,7 @@ wheels = [
 [[package]]
 name = "scikit-learn"
 version = "1.9.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "narwhals" },
@@ -3006,7 +3008,7 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.16.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -3057,7 +3059,7 @@ wheels = [
 [[package]]
 name = "secretstorage"
 version = "3.4.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "jeepney" },
@@ -3070,7 +3072,7 @@ wheels = [
 [[package]]
 name = "semantic-version"
 version = "2.10.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
@@ -3079,7 +3081,7 @@ wheels = [
 [[package]]
 name = "shapely"
 version = "2.1.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -3122,7 +3124,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -3131,7 +3133,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -3140,7 +3142,7 @@ wheels = [
 [[package]]
 name = "sortedcontainers"
 version = "2.4.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
@@ -3149,7 +3151,7 @@ wheels = [
 [[package]]
 name = "soupsieve"
 version = "2.8"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
@@ -3158,7 +3160,7 @@ wheels = [
 [[package]]
 name = "sse-starlette"
 version = "3.0.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -3170,7 +3172,7 @@ wheels = [
 [[package]]
 name = "stack-data"
 version = "0.6.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "executing" },
@@ -3184,7 +3186,7 @@ wheels = [
 [[package]]
 name = "stargazing-place-finder"
 version = "0.6.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "flask" },
     { name = "flask-cors" },
@@ -3210,7 +3212,7 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "0.50.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -3222,7 +3224,7 @@ wheels = [
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
@@ -3231,7 +3233,7 @@ wheels = [
 [[package]]
 name = "toolz"
 version = "1.1.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
@@ -3240,7 +3242,7 @@ wheels = [
 [[package]]
 name = "tornado"
 version = "6.5.4"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/37/1d/0a336abf618272d53f62ebe274f712e213f5a03c0b2339575430b8362ef2/tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7", size = 513632, upload-time = "2025-12-15T19:21:03.836Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ab/a9/e94a9d5224107d7ce3cc1fab8d5dc97f5ea351ccc6322ee4fb661da94e35/tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9", size = 443909, upload-time = "2025-12-15T19:20:48.382Z" },
@@ -3259,7 +3261,7 @@ wheels = [
 [[package]]
 name = "traitlets"
 version = "5.14.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
@@ -3268,7 +3270,7 @@ wheels = [
 [[package]]
 name = "traittypes"
 version = "0.2.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
@@ -3280,7 +3282,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -3289,7 +3291,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3301,7 +3303,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2025.2"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
@@ -3310,7 +3312,7 @@ wheels = [
 [[package]]
 name = "tzlocal"
 version = "5.3.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
@@ -3322,7 +3324,7 @@ wheels = [
 [[package]]
 name = "uncompresspy"
 version = "0.4.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/eb/fb/8c892ae2d7eb746bfc11f46f475674d2912226d8df966709d66202c88fd0/uncompresspy-0.4.1.tar.gz", hash = "sha256:e79ead66eaed8d42364d807c0ba3f3a8aef0e0087a9beaf1a60f23a808a6c147", size = 10826, upload-time = "2025-10-11T22:42:41.097Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/06/ba/baf49db30801e20a741388a9d456b7330011f45f7c7560cb2c7ab3c3fa0d/uncompresspy-0.4.1-py3-none-any.whl", hash = "sha256:b7afd3c67ec39608bfd86f2c0832deaa1ff89ed0741a2e23cdba7819ee2a47d5", size = 10076, upload-time = "2025-10-11T22:42:39.947Z" },
@@ -3331,7 +3333,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.5.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
@@ -3340,7 +3342,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.38.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
@@ -3353,7 +3355,7 @@ wheels = [
 [[package]]
 name = "wcwidth"
 version = "0.2.14"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
@@ -3362,7 +3364,7 @@ wheels = [
 [[package]]
 name = "webencodings"
 version = "0.5.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
@@ -3371,7 +3373,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "15.0.1"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
@@ -3391,7 +3393,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "3.1.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -3403,7 +3405,7 @@ wheels = [
 [[package]]
 name = "widgetsnbextension"
 version = "4.0.15"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
@@ -3412,7 +3414,7 @@ wheels = [
 [[package]]
 name = "wrapt"
 version = "1.17.3"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
@@ -3451,7 +3453,7 @@ wheels = [
 [[package]]
 name = "xyzservices"
 version = "2025.10.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/58/2b/58b3db8814e39277dd6c34aa206f7d0231ff0406284e18e03d4920a4bc78/xyzservices-2025.10.0.tar.gz", hash = "sha256:c6b7648276c98e8222fbec84d9c763128cf3653705017a4d6c4c3652480ee144", size = 1135110, upload-time = "2025-10-30T14:46:36.531Z" }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/5b/8f/447cc9cb57456d786204af0f450ffb920039104c5eff6626337c9f403bd1/xyzservices-2025.10.0-py3-none-any.whl", hash = "sha256:cfd6423367c7bc717ed5824d4dd7de2c91486886c1c193db9d8f0fa7fd43bc1b", size = 92737, upload-time = "2025-10-30T14:46:34.923Z" },
@@ -3460,7 +3462,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.22.0"
-source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/" }
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },


### PR DESCRIPTION
## Summary
- add a multi-provider weather aggregation layer for open-meteo, QWeather, and wttr.in
- expose current, hourly, and daily forecast data with cloud-cover fields in the unified response
- add provider adapters, shared models, geocoding, implementation docs, and weather service tests

## Testing
- uv run pytest tests/ -v