### PR TITLE
feat: migrate all domains to Pydantic models

### DIFF
--- a/src/functions/celestial/impl.py
+++ b/src/functions/celestial/impl.py
@@ -1,12 +1,14 @@
-from typing import Dict, Optional, Any
+from typing import Any
 import asyncio
 from datetime import datetime
 import pytz
 from src.server_instance import mcp
 from src.celestial import celestial_pos, celestial_rise_set, calculate_moon_info, get_visible_planets, get_constellation_center, calculate_nightly_forecast
+from src.models import CelestialPosition, RiseSet, MoonInfo, VisiblePlanet, ConstellationInfo, NightlyForecast, GeoPoint
 from src.utils import process_location_and_time
 
 from src.response import format_response, MCPError
+
 
 @mcp.tool()
 async def get_celestial_pos(
@@ -15,7 +17,7 @@ async def get_celestial_pos(
     lat: float,
     time: str,
     time_zone: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Calculate the altitude and azimuth angles of a celestial object.
 
     Args:
@@ -28,13 +30,12 @@ async def get_celestial_pos(
     Returns:
         Dict with keys "data", "_meta". "data" contains "altitude" and "azimuth" (degrees).
     """
+    GeoPoint(lat=lat, lon=lon)  # validate coordinates
     location, time_info = process_location_and_time(lon, lat, time, time_zone)
     # Run synchronous celestial calculations in a separate thread to avoid blocking the event loop
     alt, az = await asyncio.to_thread(celestial_pos, celestial_object, location, time_info)
-    return format_response({
-        "altitude": alt,
-        "azimuth": az
-    })
+    pos = CelestialPosition(altitude=alt, azimuth=az)
+    return format_response(pos.model_dump())
 
 @mcp.tool()
 async def get_celestial_rise_set(
@@ -43,7 +44,7 @@ async def get_celestial_rise_set(
     lat: float,
     time: str,
     time_zone: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Calculate the rise and set times of a celestial object.
 
     Args:
@@ -56,19 +57,21 @@ async def get_celestial_rise_set(
     Returns:
         Dict with keys "data", "_meta". "data" contains "rise_time" and "set_time".
     """
+    GeoPoint(lat=lat, lon=lon)  # validate coordinates
     location, time_info = process_location_and_time(lon, lat, time, time_zone)
     # Run synchronous celestial calculations in a separate thread
     rise_time, set_time = await asyncio.to_thread(celestial_rise_set, celestial_object, location, time_info)
-    return format_response({
-        "rise_time": rise_time.isoformat() if rise_time else None,
-        "set_time": set_time.isoformat() if set_time else None
-    })
+    rise_set = RiseSet(
+        rise_time=rise_time.isoformat() if rise_time else None,
+        set_time=set_time.isoformat() if set_time else None,
+    )
+    return format_response(rise_set.model_dump())
 
 @mcp.tool()
 async def get_moon_info(
     time: str,
     time_zone: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get detailed information about the Moon's phase and position.
     
     Args:
@@ -97,7 +100,8 @@ async def get_moon_info(
         dt = tz.localize(dt)
         
     result = await asyncio.to_thread(calculate_moon_info, dt)
-    return format_response(result)
+    moon_info = MoonInfo(**result)
+    return format_response(moon_info.model_dump())
 
 @mcp.tool()
 async def list_visible_planets(
@@ -105,7 +109,7 @@ async def list_visible_planets(
     lat: float,
     time: str,
     time_zone: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get a list of solar system planets currently visible (above horizon).
     
     Args:
@@ -117,11 +121,13 @@ async def list_visible_planets(
     Returns:
         Dict with keys "data", "_meta". "data" is a list of planet dicts (name, altitude, azimuth).
     """
+    GeoPoint(lat=lat, lon=lon)  # validate coordinates
     location, time_info = process_location_and_time(lon, lat, time, time_zone)
     # Avoid collision with imported function `get_visible_planets` from src.celestial
     from src.celestial import get_visible_planets as calc_visible_planets
     planets = await asyncio.to_thread(calc_visible_planets, location, time_info)
-    return format_response(planets)
+    models = [VisiblePlanet(**p) for p in planets]
+    return format_response([m.model_dump() for m in models])
 
 # Backwards-compatible alias: export the original name pointing to the decorated wrapper
 get_visible_planets = list_visible_planets
@@ -133,7 +139,7 @@ async def get_constellation(
     lat: float,
     time: str,
     time_zone: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get the position (altitude/azimuth) of the center of a constellation.
     
     Args:
@@ -146,9 +152,11 @@ async def get_constellation(
     Returns:
         Dict with keys "data", "_meta". "data" contains name, altitude, azimuth.
     """
+    GeoPoint(lat=lat, lon=lon)  # validate coordinates
     location, time_info = process_location_and_time(lon, lat, time, time_zone)
     result = await asyncio.to_thread(get_constellation_center, constellation_name, location, time_info)
-    return format_response(result)
+    const = ConstellationInfo(**result)
+    return format_response(const.model_dump())
 
 @mcp.tool()
 async def get_nightly_forecast(
@@ -157,7 +165,7 @@ async def get_nightly_forecast(
     time: str,
     time_zone: str,
     limit: int = 20
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get a curated list of best objects to view for the night.
     
     Args:
@@ -173,9 +181,16 @@ async def get_nightly_forecast(
         - planets: List of visible planets
         - deep_sky: Sorted list of deep sky objects (Messier/NGC)
     """
+    GeoPoint(lat=lat, lon=lon)  # validate coordinates
     location, time_info = process_location_and_time(lon, lat, time, time_zone)
     
     # Run in thread
     result = await asyncio.to_thread(calculate_nightly_forecast, location, time_info, limit)
     
-    return format_response(result)
+    from src.models.celestial import DeepSkyObject
+    forecast = NightlyForecast(
+        moon_phase=MoonInfo(**result["moon_phase"]),
+        planets=[VisiblePlanet(**p) for p in result["planets"]],
+        deep_sky=[DeepSkyObject(**o) for o in result["deep_sky"]],
+    )
+    return format_response(forecast.model_dump())

--- a/src/functions/places/impl.py
+++ b/src/functions/places/impl.py
@@ -1,9 +1,10 @@
-from typing import Dict, Any, List
+from typing import Any
 import asyncio
 from pathlib import Path
 from src.server_instance import mcp
 from src.placefinder import StargazingPlaceFinder, get_light_pollution_grid
 from src.cache import ANALYSIS_CACHE, generate_cache_key
+from src.models.places import LightPollutionGrid, LightPollutionGridPoint, StargazingLocation, AnalysisAreaResult
 
 from src.response import format_response
 
@@ -11,7 +12,7 @@ from src.response import format_response
 async def light_pollution_map(
     south: float, west: float, north: float, east: float,
     zoom: int = 10
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get light pollution data for a specific area.
     
     Returns a grid of light pollution data points including brightness, Bortle class, and SQM.
@@ -23,8 +24,13 @@ async def light_pollution_map(
     def _compute():
         return get_light_pollution_grid(north=north, south=south, east=east, west=west, zoom=zoom)
 
-    result = await asyncio.to_thread(_compute)
-    return format_response(result)
+    raw = await asyncio.to_thread(_compute)
+    grid = LightPollutionGrid(
+        grid=[LightPollutionGridPoint(**p) for p in raw.get("grid", [])],
+        bounds={"south": south, "west": west, "north": north, "east": east},
+        zoom=zoom,
+    )
+    return format_response(grid.model_dump())
 
 @mcp.tool()
 async def analysis_area(
@@ -36,7 +42,7 @@ async def analysis_area(
     db_config_path: str = None,
     page: int = 1,
     page_size: int = 10
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Analyze a geographic area for suitable stargazing locations.
     
     This tool searches for dark, accessible locations with good viewing conditions.
@@ -72,10 +78,10 @@ async def analysis_area(
     resource_id = generate_cache_key(**calc_params)
     
     # 2. Check Cache
-    all_results = ANALYSIS_CACHE.get(resource_id)
+    cached = ANALYSIS_CACHE.get(resource_id)
     
     # 3. If miss, compute (in thread)
-    if all_results is None:
+    if cached is None:
         def _compute():
             db_config_p = Path(db_config_path) if db_config_path else None
             stargazing_place_finder = StargazingPlaceFinder(db_config_path=db_config_p)
@@ -89,38 +95,26 @@ async def analysis_area(
                 max_locations=max_locations,
                 network_type=network_type,
             )
-            
-            # Ensure results are serializable
-            serialized = []
-            for item in results:
-                if isinstance(item, dict):
-                    serialized.append(item)
-                elif hasattr(item, "model_dump") and callable(item.model_dump):
-                    serialized.append(item.model_dump(exclude_none=True))
-                elif hasattr(item, "to_dict") and callable(item.to_dict):
-                    serialized.append(item.to_dict())
-                elif hasattr(item, "__dict__"):
-                    serialized.append(vars(item))
-                else:
-                    serialized.append(str(item))
-            return serialized
+            # Convert raw dict results to StargazingLocation models
+            return [StargazingLocation(**item) if isinstance(item, dict) else item for item in results]
 
-        all_results = await asyncio.to_thread(_compute)
-        ANALYSIS_CACHE.set(resource_id, all_results)
+        cached = await asyncio.to_thread(_compute)
+        ANALYSIS_CACHE.set(resource_id, cached)
         
     # 4. Pagination
-    total = len(all_results)
+    total = len(cached)
     start_idx = (page - 1) * page_size
     end_idx = start_idx + page_size
     
     # Slice results (safe even if indices are out of bounds)
-    page_items = all_results[start_idx:end_idx]
+    page_items = cached[start_idx:end_idx]
     
-    return format_response({
-        "items": page_items,
-        "total": total,
-        "page": page,
-        "page_size": page_size,
-        "total_pages": (total + page_size - 1) // page_size if page_size > 0 else 0,
-        "resource_id": resource_id
-    })
+    result = AnalysisAreaResult(
+        items=page_items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=(total + page_size - 1) // page_size if page_size > 0 else 0,
+        resource_id=resource_id,
+    )
+    return format_response(result.model_dump())

--- a/src/functions/weather/geocoding.py
+++ b/src/functions/weather/geocoding.py
@@ -3,10 +3,11 @@
 from geopy.exc import GeocoderServiceError, GeocoderTimedOut
 from geopy.geocoders import Nominatim
 
+from src.models.weather import LocationInfo
 from src.response import MCPError
 
 
-def resolve_place_name(place_name: str) -> dict:
+def resolve_place_name(place_name: str) -> LocationInfo:
     """将地点名称解析为标准位置对象。"""
 
     cleaned_name = place_name.strip()
@@ -20,7 +21,7 @@ def resolve_place_name(place_name: str) -> dict:
     return _resolve_with_nominatim(cleaned_name)
 
 
-def _resolve_with_nominatim(place_name: str) -> dict:
+def _resolve_with_nominatim(place_name: str) -> LocationInfo:
     """使用 Nominatim 地理编码服务解析地点名称。"""
 
     geocoder = Nominatim(user_agent="mcp-stargazing")
@@ -47,25 +48,9 @@ def _resolve_with_nominatim(place_name: str) -> dict:
         )
 
     display_name = getattr(result, "address", None) or place_name
-    return normalize_geocoding_result(
+    return LocationInfo(
         name=display_name,
         lat=float(result.latitude),
         lon=float(result.longitude),
         timezone=None,
     )
-
-
-def normalize_geocoding_result(
-    name: str,
-    lat: float,
-    lon: float,
-    timezone: str | None = None,
-) -> dict:
-    """将地理编码结果标准化为统一位置结构。"""
-
-    return {
-        "name": name,
-        "lat": lat,
-        "lon": lon,
-        "timezone": timezone,
-    }

--- a/src/functions/weather/impl.py
+++ b/src/functions/weather/impl.py
@@ -1,11 +1,32 @@
+from pydantic import BaseModel, Field, field_validator
+
 from src.server_instance import mcp
 from src.functions.weather.providers.qweather import get_qweather_auth_from_env
 from src.functions.weather.service import (
     get_aggregated_weather_by_name,
     get_aggregated_weather_by_position,
 )
+from src.models import GeoPoint
+from src.models.weather import AggregatedWeatherResponse
 from src.response import format_response, MCPError
 from src.retry import retry_on_failure, RetryConfig
+
+
+class WeatherQuery(BaseModel):
+    """Validated input for weather queries."""
+
+    provider: str = Field(default="all")
+
+    @field_validator("provider")
+    @classmethod
+    def normalize_provider(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        allowed = {"all", "qweather", "open-meteo", "wttr"}
+        if normalized not in allowed:
+            raise ValueError(
+                f"Unsupported provider: '{v}'. Allowed: {sorted(allowed)}"
+            )
+        return normalized
 
 
 def _get_qweather_auth_from_env() -> tuple[str | None, str | None, str | None]:
@@ -36,16 +57,18 @@ def get_weather_by_name(place_name: str, provider: str = "all"):
             "place_name 不能为空。",
             {"place_name": place_name},
         )
-    normalized_provider = _validate_provider(provider)
+    WeatherQuery(provider=provider)  # validates via Pydantic
 
     @retry_on_failure(
         RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
         retryable_errors=(ConnectionError, TimeoutError, OSError)
     )
     def _fetch_weather():
-        return get_aggregated_weather_by_name(cleaned_name, provider=normalized_provider)
+        return get_aggregated_weather_by_name(cleaned_name, provider=provider)
 
     result = _fetch_weather()
+    if isinstance(result, AggregatedWeatherResponse):
+        return format_response(result.model_dump())
     return format_response(result)
 
 
@@ -65,40 +88,17 @@ def get_weather_by_position(lat: float, lon: float, provider: str = "all"):
     Raises:
         MCPError: For validation failures, API errors, or network issues.
     """
-    _validate_coordinates(lat, lon)
-    normalized_provider = _validate_provider(provider)
+    GeoPoint(lat=lat, lon=lon)  # validates via Pydantic
+    WeatherQuery(provider=provider)  # validates via Pydantic
 
     @retry_on_failure(
         RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
         retryable_errors=(ConnectionError, TimeoutError, OSError)
     )
     def _fetch_weather():
-        return get_aggregated_weather_by_position(lat, lon, provider=normalized_provider)
+        return get_aggregated_weather_by_position(lat, lon, provider=provider)
 
     result = _fetch_weather()
+    if isinstance(result, AggregatedWeatherResponse):
+        return format_response(result.model_dump())
     return format_response(result)
-
-
-def _validate_provider(provider: str) -> str:
-    """校验 provider 参数并返回规范化值。"""
-
-    normalized = provider.strip().lower()
-    allowed = {"all", "qweather", "open-meteo", "wttr"}
-    if normalized not in allowed:
-        raise MCPError(
-            MCPError.CONFIGURATION_ERROR,
-            f"不支持的天气 provider: {provider}",
-            {"provider": provider, "allowed": sorted(allowed)},
-        )
-    return normalized
-
-
-def _validate_coordinates(lat: float, lon: float) -> None:
-    """校验经纬度是否合法。"""
-
-    if not (-90 <= lat <= 90) or not (-180 <= lon <= 180):
-        raise MCPError(
-            MCPError.INVALID_COORDINATES,
-            f"Invalid coordinates: lat={lat}, lon={lon}",
-            {"lat": lat, "lon": lon},
-        )

--- a/src/functions/weather/models.py
+++ b/src/functions/weather/models.py
@@ -1,154 +1,32 @@
-"""Shared payload builders for aggregated weather responses."""
+"""Re-exports of weather Pydantic models for backward compatibility.
 
+New code should import directly from src.models or src.models.weather.
+"""
 
-def build_location_payload(
-    name: str | None,
-    lat: float,
-    lon: float,
-    timezone: str | None,
-) -> dict:
-    """构造统一的位置数据结构。"""
+from src.models.weather import (
+    LocationInfo,
+    CurrentWeather,
+    DailyForecastItem,
+    HourlyForecastItem,
+    ProviderSuccess,
+    ProviderError,
+    ProviderErrorDetail,
+    NormalizedWeatherData,
+    AggregatedWeatherResponse,
+    WeatherSummary,
+    SourceMeta,
+)
 
-    return {
-        "name": name,
-        "lat": lat,
-        "lon": lon,
-        "timezone": timezone,
-    }
-
-
-def build_current_weather_payload(
-    temperature_c: float | None = None,
-    feels_like_c: float | None = None,
-    humidity: float | None = None,
-    wind_speed_kph: float | None = None,
-    wind_direction_deg: float | None = None,
-    pressure_hpa: float | None = None,
-    visibility_km: float | None = None,
-    cloud_cover_percent: float | None = None,
-    cloud_cover_low_percent: float | None = None,
-    cloud_cover_mid_percent: float | None = None,
-    cloud_cover_high_percent: float | None = None,
-    weather_code: str | None = None,
-    weather_text: str | None = None,
-    observation_time: str | None = None,
-) -> dict:
-    """构造统一的当前天气数据结构。"""
-
-    return {
-        "temperature_c": temperature_c,
-        "feels_like_c": feels_like_c,
-        "humidity": humidity,
-        "wind_speed_kph": wind_speed_kph,
-        "wind_direction_deg": wind_direction_deg,
-        "pressure_hpa": pressure_hpa,
-        "visibility_km": visibility_km,
-        "cloud_cover_percent": cloud_cover_percent,
-        "cloud_cover_low_percent": cloud_cover_low_percent,
-        "cloud_cover_mid_percent": cloud_cover_mid_percent,
-        "cloud_cover_high_percent": cloud_cover_high_percent,
-        "weather_code": weather_code,
-        "weather_text": weather_text,
-        "observation_time": observation_time,
-    }
-
-
-def build_daily_forecast_item(
-    date: str,
-    temp_min_c: float | None = None,
-    temp_max_c: float | None = None,
-    precipitation_probability: float | None = None,
-    cloud_cover_percent: float | None = None,
-    weather_code_day: str | None = None,
-    weather_text_day: str | None = None,
-) -> dict:
-    """构造统一的单日预报数据结构。"""
-
-    return {
-        "date": date,
-        "temp_min_c": temp_min_c,
-        "temp_max_c": temp_max_c,
-        "precipitation_probability": precipitation_probability,
-        "cloud_cover_percent": cloud_cover_percent,
-        "weather_code_day": weather_code_day,
-        "weather_text_day": weather_text_day,
-    }
-
-
-def build_hourly_forecast_item(
-    time: str,
-    temperature_c: float | None = None,
-    humidity: float | None = None,
-    precipitation_probability: float | None = None,
-    wind_speed_kph: float | None = None,
-    wind_direction_deg: float | None = None,
-    cloud_cover_percent: float | None = None,
-    cloud_cover_low_percent: float | None = None,
-    cloud_cover_mid_percent: float | None = None,
-    cloud_cover_high_percent: float | None = None,
-    weather_code: str | None = None,
-    weather_text: str | None = None,
-) -> dict:
-    """构造统一的单小时预报数据结构。"""
-
-    return {
-        "time": time,
-        "temperature_c": temperature_c,
-        "humidity": humidity,
-        "precipitation_probability": precipitation_probability,
-        "wind_speed_kph": wind_speed_kph,
-        "wind_direction_deg": wind_direction_deg,
-        "cloud_cover_percent": cloud_cover_percent,
-        "cloud_cover_low_percent": cloud_cover_low_percent,
-        "cloud_cover_mid_percent": cloud_cover_mid_percent,
-        "cloud_cover_high_percent": cloud_cover_high_percent,
-        "weather_code": weather_code,
-        "weather_text": weather_text,
-    }
-
-
-def build_provider_success_payload(provider_name: str, data: dict) -> dict:
-    """构造 provider 成功状态结果。"""
-
-    return {
-        "status": "success",
-        "provider": provider_name,
-        "data": data,
-    }
-
-
-def build_provider_error_payload(
-    provider_name: str,
-    code: str,
-    message: str,
-    details: dict | None = None,
-) -> dict:
-    """构造 provider 失败状态结果。"""
-
-    error = {
-        "code": code,
-        "message": message,
-    }
-    if details:
-        error["details"] = details
-    return {
-        "status": "error",
-        "provider": provider_name,
-        "error": error,
-    }
-
-
-def build_aggregated_weather_payload(
-    location: dict,
-    summary: dict,
-    providers: dict,
-    source: dict,
-) -> dict:
-    """构造最终综合天气响应数据结构。"""
-
-    return {
-        "location": location,
-        "summary": summary,
-        "providers": providers,
-        "source": source,
-    }
+__all__ = [
+    "LocationInfo",
+    "CurrentWeather",
+    "DailyForecastItem",
+    "HourlyForecastItem",
+    "ProviderSuccess",
+    "ProviderError",
+    "ProviderErrorDetail",
+    "NormalizedWeatherData",
+    "AggregatedWeatherResponse",
+    "WeatherSummary",
+    "SourceMeta",
+]

--- a/src/functions/weather/providers/open_meteo.py
+++ b/src/functions/weather/providers/open_meteo.py
@@ -2,11 +2,13 @@
 
 import requests
 
-from src.functions.weather.models import (
-    build_current_weather_payload,
-    build_daily_forecast_item,
-    build_hourly_forecast_item,
-    build_provider_success_payload,
+from src.models.weather import (
+    CurrentWeather,
+    DailyForecastItem,
+    HourlyForecastItem,
+    LocationInfo,
+    NormalizedWeatherData,
+    ProviderSuccess,
 )
 from src.response import MCPError
 
@@ -18,7 +20,7 @@ def get_weather_by_position(
     lon: float,
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
+) -> ProviderSuccess:
     """查询 Open-Meteo 并返回标准化后的 provider 结果。"""
 
     raw_data = fetch_open_meteo_raw_weather(lat, lon, timezone=timezone)
@@ -29,7 +31,7 @@ def get_weather_by_position(
         location_name=location_name,
         timezone=timezone,
     )
-    return build_provider_success_payload("open-meteo", normalized)
+    return ProviderSuccess(provider="open-meteo", data=normalized)
 
 
 def build_open_meteo_url(
@@ -105,7 +107,7 @@ def normalize_open_meteo_weather(
     lon: float,
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
+) -> NormalizedWeatherData:
     """将 Open-Meteo 原始响应映射为统一天气结构。"""
 
     current = raw_data.get("current", {})
@@ -113,14 +115,14 @@ def normalize_open_meteo_weather(
     hourly = raw_data.get("hourly", {})
     resolved_timezone = raw_data.get("timezone", timezone)
 
-    return {
-        "location": {
-            "name": location_name,
-            "lat": lat,
-            "lon": lon,
-            "timezone": resolved_timezone,
-        },
-        "current": build_current_weather_payload(
+    return NormalizedWeatherData(
+        location=LocationInfo(
+            name=location_name,
+            lat=lat,
+            lon=lon,
+            timezone=resolved_timezone,
+        ),
+        current=CurrentWeather(
             temperature_c=_to_float(current.get("temperature_2m")),
             feels_like_c=_to_float(current.get("apparent_temperature")),
             humidity=_to_float(current.get("relative_humidity_2m")),
@@ -136,8 +138,8 @@ def normalize_open_meteo_weather(
             weather_text=_weather_text_from_open_meteo_code(current.get("weather_code")),
             observation_time=current.get("time"),
         ),
-        "daily": [
-            build_daily_forecast_item(
+        daily=[
+            DailyForecastItem(
                 date=date,
                 temp_min_c=_safe_index(daily.get("temperature_2m_min"), idx),
                 temp_max_c=_safe_index(daily.get("temperature_2m_max"), idx),
@@ -148,8 +150,8 @@ def normalize_open_meteo_weather(
             )
             for idx, date in enumerate(daily.get("time", []))
         ],
-        "hourly": [
-            build_hourly_forecast_item(
+        hourly=[
+            HourlyForecastItem(
                 time=time_value,
                 temperature_c=_safe_index(hourly.get("temperature_2m"), idx),
                 humidity=_safe_index(hourly.get("relative_humidity_2m"), idx),
@@ -165,7 +167,7 @@ def normalize_open_meteo_weather(
             )
             for idx, time_value in enumerate(hourly.get("time", []))
         ],
-    }
+    )
 
 
 def map_open_meteo_weather_code(code: int | None) -> str | None:

--- a/src/functions/weather/providers/qweather.py
+++ b/src/functions/weather/providers/qweather.py
@@ -2,11 +2,13 @@
 
 import os
 
-from src.functions.weather.models import (
-    build_current_weather_payload,
-    build_daily_forecast_item,
-    build_hourly_forecast_item,
-    build_provider_success_payload,
+from src.models.weather import (
+    CurrentWeather,
+    DailyForecastItem,
+    HourlyForecastItem,
+    LocationInfo,
+    NormalizedWeatherData,
+    ProviderSuccess,
 )
 from src.qweather_interaction import (
     qweather_get_weather_by_coord_in_ten_days,
@@ -36,7 +38,7 @@ def get_weather_by_position(
     lon: float,
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
+) -> ProviderSuccess:
     """查询 QWeather 并返回标准化后的 provider 结果。"""
 
     raw_data = fetch_qweather_raw_weather(lat, lon)
@@ -47,7 +49,7 @@ def get_weather_by_position(
         location_name=location_name,
         timezone=timezone,
     )
-    return build_provider_success_payload("qweather", normalized)
+    return ProviderSuccess(provider="qweather", data=normalized)
 
 
 def fetch_qweather_raw_weather(lat: float, lon: float) -> dict:
@@ -85,21 +87,21 @@ def normalize_qweather_weather(
     lon: float,
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
+) -> NormalizedWeatherData:
     """将 QWeather 原始响应映射为统一天气结构。"""
 
     current = raw_data.get("current", {}).get("now", {})
     daily_rows = raw_data.get("daily", {}).get("daily", [])
     hourly_rows = raw_data.get("hourly", {}).get("hourly", [])
 
-    return {
-        "location": {
-            "name": location_name,
-            "lat": lat,
-            "lon": lon,
-            "timezone": timezone,
-        },
-        "current": build_current_weather_payload(
+    return NormalizedWeatherData(
+        location=LocationInfo(
+            name=location_name,
+            lat=lat,
+            lon=lon,
+            timezone=timezone,
+        ),
+        current=CurrentWeather(
             temperature_c=_to_float(current.get("temp")),
             feels_like_c=_to_float(current.get("feelsLike")),
             humidity=_to_float(current.get("humidity")),
@@ -115,8 +117,8 @@ def normalize_qweather_weather(
             weather_text=current.get("text"),
             observation_time=current.get("obsTime"),
         ),
-        "daily": [
-            build_daily_forecast_item(
+        daily=[
+            DailyForecastItem(
                 date=row.get("fxDate"),
                 temp_min_c=_to_float(row.get("tempMin")),
                 temp_max_c=_to_float(row.get("tempMax")),
@@ -128,8 +130,8 @@ def normalize_qweather_weather(
             for row in daily_rows
             if row.get("fxDate")
         ],
-        "hourly": [
-            build_hourly_forecast_item(
+        hourly=[
+            HourlyForecastItem(
                 time=row.get("fxTime"),
                 temperature_c=_to_float(row.get("temp")),
                 humidity=_to_float(row.get("humidity")),
@@ -146,7 +148,7 @@ def normalize_qweather_weather(
             for row in hourly_rows
             if row.get("fxTime")
         ],
-    }
+    )
 
 
 def map_qweather_condition_code(code: str | None) -> str | None:

--- a/src/functions/weather/providers/wttr.py
+++ b/src/functions/weather/providers/wttr.py
@@ -2,11 +2,13 @@
 
 import requests
 
-from src.functions.weather.models import (
-    build_current_weather_payload,
-    build_daily_forecast_item,
-    build_hourly_forecast_item,
-    build_provider_success_payload,
+from src.models.weather import (
+    CurrentWeather,
+    DailyForecastItem,
+    HourlyForecastItem,
+    LocationInfo,
+    NormalizedWeatherData,
+    ProviderSuccess,
 )
 from src.response import MCPError
 
@@ -16,7 +18,7 @@ def get_weather_by_position(
     lon: float,
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
+) -> ProviderSuccess:
     """查询 wttr.in 并返回标准化后的 provider 结果。"""
 
     raw_data = fetch_wttr_raw_weather(lat, lon)
@@ -27,7 +29,7 @@ def get_weather_by_position(
         location_name=location_name,
         timezone=timezone,
     )
-    return build_provider_success_payload("wttr", normalized)
+    return ProviderSuccess(provider="wttr", data=normalized)
 
 
 def build_wttr_query(lat: float, lon: float) -> str:
@@ -87,7 +89,7 @@ def normalize_wttr_weather(
     lon: float,
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
+) -> NormalizedWeatherData:
     """将 wttr.in 原始响应映射为统一天气结构。"""
 
     current = (raw_data.get("current_condition") or [{}])[0]
@@ -98,12 +100,12 @@ def normalize_wttr_weather(
         if area_names:
             location_name = area_names[0].get("value")
 
-    daily_items: list[dict] = []
-    hourly_items: list[dict] = []
+    daily_items: list[DailyForecastItem] = []
+    hourly_items: list[HourlyForecastItem] = []
     for weather_row in weather_rows:
         hourly_rows = weather_row.get("hourly") or []
         daily_items.append(
-            build_daily_forecast_item(
+            DailyForecastItem(
                 date=weather_row.get("date"),
                 temp_min_c=_to_float(weather_row.get("mintempC")),
                 temp_max_c=_to_float(weather_row.get("maxtempC")),
@@ -115,14 +117,14 @@ def normalize_wttr_weather(
         )
         hourly_items.extend(_build_hourly_items(weather_row.get("date"), hourly_rows))
 
-    return {
-        "location": {
-            "name": location_name,
-            "lat": lat,
-            "lon": lon,
-            "timezone": timezone,
-        },
-        "current": build_current_weather_payload(
+    return NormalizedWeatherData(
+        location=LocationInfo(
+            name=location_name,
+            lat=lat,
+            lon=lon,
+            timezone=timezone,
+        ),
+        current=CurrentWeather(
             temperature_c=_to_float(current.get("temp_C")),
             feels_like_c=_to_float(current.get("FeelsLikeC")),
             humidity=_to_float(current.get("humidity")),
@@ -138,9 +140,9 @@ def normalize_wttr_weather(
             weather_text=_condition_text_from_row(current),
             observation_time=current.get("localObsDateTime"),
         ),
-        "daily": [item for item in daily_items if item["date"]],
-        "hourly": hourly_items,
-    }
+        daily=[item for item in daily_items if item.date],
+        hourly=hourly_items,
+    )
 
 
 def map_wttr_condition_text(text: str | None) -> str | None:
@@ -164,16 +166,16 @@ def map_wttr_condition_text(text: str | None) -> str | None:
     return "unknown"
 
 
-def _build_hourly_items(date_value: str | None, hourly_rows: list[dict]) -> list[dict]:
+def _build_hourly_items(date_value: str | None, hourly_rows: list[dict]) -> list[HourlyForecastItem]:
     """构造 wttr.in 的小时级预报列表。"""
 
-    items: list[dict] = []
+    items: list[HourlyForecastItem] = []
     for row in hourly_rows:
         time_value = _combine_wttr_date_and_time(date_value, row.get("time"))
         if time_value is None:
             continue
         items.append(
-            build_hourly_forecast_item(
+            HourlyForecastItem(
                 time=time_value,
                 temperature_c=_to_float(row.get("tempC")),
                 humidity=_to_float(row.get("humidity")),

--- a/src/functions/weather/service.py
+++ b/src/functions/weather/service.py
@@ -1,13 +1,21 @@
-"""Aggregation service for multi-provider weather queries."""
+"""Aggregation service for multi-provider weather queries.
+
+Internally uses Pydantic models for type-safe data handling.
+Public API functions return AggregatedWeatherResponse (a Pydantic model).
+"""
 
 from src.functions.weather.geocoding import resolve_place_name
-from src.functions.weather.models import (
-    build_aggregated_weather_payload,
-    build_current_weather_payload,
-    build_location_payload,
-    build_provider_error_payload,
-)
 from src.functions.weather.providers import open_meteo, qweather, wttr
+from src.models import ProviderType
+from src.models.weather import (
+    AggregatedWeatherResponse,
+    LocationInfo,
+    ProviderError,
+    ProviderErrorDetail,
+    ProviderSuccess,
+    SourceMeta,
+    WeatherSummary,
+)
 from src.response import MCPError
 
 PROVIDER_ORDER = ["open-meteo", "qweather", "wttr"]
@@ -16,16 +24,16 @@ PROVIDER_ORDER = ["open-meteo", "qweather", "wttr"]
 def get_aggregated_weather_by_name(
     place_name: str,
     provider: str = "all",
-) -> dict:
+) -> AggregatedWeatherResponse:
     """根据地点名称查询并聚合多个天气提供商的结果。"""
 
     location = resolve_place_name(place_name)
     return get_aggregated_weather_by_position(
-        location["lat"],
-        location["lon"],
+        location.lat,
+        location.lon,
         provider=provider,
-        location_name=location.get("name"),
-        timezone=location.get("timezone"),
+        location_name=location.name,
+        timezone=location.timezone,
     )
 
 
@@ -35,83 +43,65 @@ def get_aggregated_weather_by_position(
     provider: str = "all",
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
+) -> AggregatedWeatherResponse:
     """根据经纬度查询并聚合多个天气提供商的结果。"""
 
-    provider_names = get_enabled_providers(provider)
-    provider_results = query_providers_by_position(
-        lat,
-        lon,
-        provider_names,
-        location_name=location_name,
-        timezone=timezone,
-    )
+    provider_type = ProviderType.from_str(provider)
+    provider_names = _get_enabled_providers(provider_type)
+
+    provider_results: dict[str, ProviderSuccess | ProviderError] = {}
+    for pname in provider_names:
+        try:
+            provider_results[pname] = _query_single_provider(
+                pname, lat, lon,
+                location_name=location_name,
+                timezone=timezone,
+            )
+        except MCPError as exc:
+            provider_results[pname] = ProviderError(
+                provider=pname,
+                error=ProviderErrorDetail(code=exc.code, message=exc.message, details=exc.details),
+            )
+        except Exception as exc:
+            provider_results[pname] = ProviderError(
+                provider=pname,
+                error=ProviderErrorDetail(
+                    code=MCPError.EXTERNAL_API_ERROR,
+                    message=f"{pname} provider 查询失败: {exc}",
+                    details={"lat": lat, "lon": lon},
+                ),
+            )
+
     _ensure_any_provider_success(provider_results)
 
-    successful_provider_data = [
-        {"provider": result["provider"], "data": result["data"]}
-        for result in provider_results.values()
-        if result["status"] == "success"
+    successful_providers = [
+        r for r in provider_results.values() if isinstance(r, ProviderSuccess)
     ]
-    location_payload = _build_location(lat, lon, location_name, timezone, successful_provider_data)
-    summary = _build_summary(successful_provider_data)
+
+    location = _build_location(lat, lon, location_name, timezone, successful_providers)
+    summary = _build_summary(successful_providers)
     source = _build_source_meta(provider, provider_results)
-    return build_aggregated_weather_payload(
-        location=location_payload,
+
+    return AggregatedWeatherResponse(
+        location=location,
         summary=summary,
         providers=provider_results,
         source=source,
     )
 
 
-def get_enabled_providers(provider: str) -> list[str]:
-    """根据 provider 参数返回需要查询的 provider 列表。"""
+def _get_enabled_providers(provider_type: ProviderType) -> list[str]:
+    """根据 provider 类型返回需要查询的 provider 列表。"""
 
-    if provider == "all":
+    if provider_type == ProviderType.ALL:
         return PROVIDER_ORDER[:]
-    if provider in PROVIDER_ORDER:
-        return [provider]
+    if provider_type.value in PROVIDER_ORDER:
+        return [provider_type.value]
     raise MCPError(
         MCPError.CONFIGURATION_ERROR,
-        f"不支持的天气 provider: {provider}",
-        {"provider": provider, "allowed": ["all", *PROVIDER_ORDER]},
+        f"不支持的天气 provider: {provider_type.value}",
+        {"provider": provider_type.value, "allowed": ["all", *PROVIDER_ORDER]},
     )
-
-
-def query_providers_by_position(
-    lat: float,
-    lon: float,
-    provider_names: list[str],
-    location_name: str | None = None,
-    timezone: str | None = None,
-) -> dict:
-    """按 provider 列表查询天气，并返回各 provider 的结果状态。"""
-
-    results: dict[str, dict] = {}
-    for provider_name in provider_names:
-        try:
-            results[provider_name] = _query_single_provider(
-                provider_name,
-                lat,
-                lon,
-                location_name=location_name,
-                timezone=timezone,
-            )
-        except MCPError as exc:
-            results[provider_name] = build_provider_error_payload(
-                provider_name,
-                exc.code,
-                exc.message,
-                exc.details,
-            )
-        except Exception as exc:
-            results[provider_name] = build_provider_error_payload(
-                provider_name,
-                MCPError.EXTERNAL_API_ERROR,
-                f"{provider_name} provider 查询失败: {exc}",
-                {"lat": lat, "lon": lon},
-            )
-    return results
 
 
 def _query_single_provider(
@@ -120,8 +110,8 @@ def _query_single_provider(
     lon: float,
     location_name: str | None = None,
     timezone: str | None = None,
-) -> dict:
-    """查询单个 provider 并返回标准化后的 provider 结果。"""
+) -> ProviderSuccess:
+    """查询单个 provider 并返回 ProviderSuccess 模型。"""
 
     if provider_name == "open-meteo":
         return open_meteo.get_weather_by_position(lat, lon, location_name=location_name, timezone=timezone)
@@ -136,100 +126,99 @@ def _query_single_provider(
     )
 
 
-def _build_summary(successful_provider_data: list[dict]) -> dict:
-    """根据多个 provider 的标准化结果生成综合天气摘要。"""
+def _build_summary(successful_providers: list[ProviderSuccess]) -> WeatherSummary:
+    """根据多个成功 provider 的标准化结果生成综合天气摘要。"""
 
-    return {
-        "current": _build_summary_current(successful_provider_data),
-        "daily": _build_summary_daily(successful_provider_data),
-        "hourly": _build_summary_hourly(successful_provider_data),
-    }
-
-
-def _build_summary_current(successful_provider_data: list[dict]) -> dict:
-    """从多个成功 provider 中生成统一的当前天气摘要。"""
-
-    primary_provider = _select_primary_provider_for_summary(successful_provider_data)
-    primary_data = next(
-        (item["data"]["current"] for item in successful_provider_data if item["provider"] == primary_provider),
-        {},
+    return WeatherSummary(
+        current=_build_summary_current(successful_providers),
+        daily=_build_summary_daily(successful_providers),
+        hourly=_build_summary_hourly(successful_providers),
     )
-    merged = build_current_weather_payload(**primary_data)
+
+
+def _build_summary_current(successful_providers: list[ProviderSuccess]) -> dict:
+    """从多个成功 provider 中生成统一的当前天气摘要。
+
+    Uses the preferred provider's data, falling back to others for None fields.
+    """
+
+    primary_provider = _select_primary_provider(successful_providers)
+    if primary_provider is None:
+        return {}
+
+    primary = primary_provider.data.current
+    merged = primary.model_dump()
 
     for field_name in merged:
         if merged[field_name] is not None:
             continue
-        for item in successful_provider_data:
-            value = item["data"].get("current", {}).get(field_name)
+        for p in successful_providers:
+            value = getattr(p.data.current, field_name, None)
             if value is not None:
                 merged[field_name] = value
                 break
     return merged
 
 
-def _build_summary_daily(successful_provider_data: list[dict]) -> list[dict]:
+def _build_summary_daily(successful_providers: list[ProviderSuccess]) -> list[dict]:
     """从多个成功 provider 中生成统一的日级天气预报摘要。"""
 
     for provider_name in PROVIDER_ORDER:
-        for item in successful_provider_data:
-            if item["provider"] == provider_name and item["data"].get("daily"):
-                return item["data"]["daily"]
+        for p in successful_providers:
+            if p.provider == provider_name and p.data.daily:
+                return [d.model_dump() for d in p.data.daily]
     return []
 
 
-def _build_summary_hourly(successful_provider_data: list[dict]) -> list[dict]:
+def _build_summary_hourly(successful_providers: list[ProviderSuccess]) -> list[dict]:
     """从多个成功 provider 中生成统一的小时级天气预报摘要。"""
 
     for provider_name in PROVIDER_ORDER:
-        for item in successful_provider_data:
-            if item["provider"] == provider_name and item["data"].get("hourly"):
-                return item["data"]["hourly"]
+        for p in successful_providers:
+            if p.provider == provider_name and p.data.hourly:
+                return [h.model_dump() for h in p.data.hourly]
     return []
 
 
-def _select_primary_provider_for_summary(successful_provider_data: list[dict]) -> str | None:
-    """选择用于生成摘要的主 provider。"""
+def _select_primary_provider(successful_providers: list[ProviderSuccess]) -> ProviderSuccess | None:
+    """选择用于生成摘要的首选 provider（按 PROVIDER_ORDER 优先级）。"""
 
     for provider_name in PROVIDER_ORDER:
-        if any(item["provider"] == provider_name for item in successful_provider_data):
-            return provider_name
+        for p in successful_providers:
+            if p.provider == provider_name:
+                return p
     return None
 
 
 def _build_source_meta(
     requested_provider: str,
-    provider_results: dict,
-) -> dict:
+    provider_results: dict[str, ProviderSuccess | ProviderError],
+) -> SourceMeta:
     """根据 provider 查询结果构造来源元信息。"""
 
     successful = [
-        result["provider"]
-        for result in provider_results.values()
-        if result["status"] == "success"
+        r.provider for r in provider_results.values() if isinstance(r, ProviderSuccess)
     ]
     failed = [
-        result["provider"]
-        for result in provider_results.values()
-        if result["status"] == "error"
+        r.provider for r in provider_results.values() if isinstance(r, ProviderError)
     ]
-    return {
-        "query_mode": requested_provider,
-        "successful_providers": successful,
-        "failed_providers": failed,
-        "summary_provider_policy": "open-meteo-first",
-    }
+    return SourceMeta(
+        query_mode=requested_provider,
+        successful_providers=successful,
+        failed_providers=failed,
+        summary_provider_policy="open-meteo-first",
+    )
 
 
-def _ensure_any_provider_success(provider_results: dict) -> None:
+def _ensure_any_provider_success(provider_results: dict[str, ProviderSuccess | ProviderError]) -> None:
     """确保至少有一个 provider 查询成功，否则抛出错误。"""
 
-    if any(result["status"] == "success" for result in provider_results.values()):
+    if any(isinstance(r, ProviderSuccess) for r in provider_results.values()):
         return
 
     errors = {
-        provider_name: result["error"]
-        for provider_name, result in provider_results.items()
-        if result["status"] == "error"
+        name: r.error.model_dump() if isinstance(r, ProviderError) else {}
+        for name, r in provider_results.items()
     }
     raise MCPError(
         MCPError.EXTERNAL_API_ERROR,
@@ -243,16 +232,16 @@ def _build_location(
     lon: float,
     location_name: str | None,
     timezone: str | None,
-    successful_provider_data: list[dict],
-) -> dict:
+    successful_providers: list[ProviderSuccess],
+) -> LocationInfo:
     """构造聚合结果的位置对象。"""
 
     resolved_name = location_name
     resolved_timezone = timezone
-    for item in successful_provider_data:
-        provider_location = item["data"].get("location", {})
-        if resolved_name is None and provider_location.get("name") is not None:
-            resolved_name = provider_location.get("name")
-        if resolved_timezone is None and provider_location.get("timezone") is not None:
-            resolved_timezone = provider_location.get("timezone")
-    return build_location_payload(resolved_name, lat, lon, resolved_timezone)
+    for p in successful_providers:
+        loc = p.data.location
+        if resolved_name is None and loc.name is not None:
+            resolved_name = loc.name
+        if resolved_timezone is None and loc.timezone is not None:
+            resolved_timezone = loc.timezone
+    return LocationInfo(name=resolved_name, lat=lat, lon=lon, timezone=resolved_timezone)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,78 @@
+"""Shared Pydantic models for the MCP Stargazing server.
+
+These models define the contract between modules — any internal function
+should accept and return these models rather than raw dicts.
+"""
+
+from src.models.base import (
+    GeoPoint,
+    GeoBounds,
+    TimeInfo,
+    ProviderType,
+)
+from src.models.celestial import (
+    CelestialPosition,
+    RiseSet,
+    MoonInfo,
+    VisiblePlanet,
+    ConstellationInfo,
+    DeepSkyObject,
+    NightlyForecast,
+)
+from src.models.error import ErrorCode
+from src.models.pagination import PaginatedResult
+from src.models.places import (
+    LightPollutionGridPoint,
+    LightPollutionGrid,
+    StargazingLocation,
+    AnalysisAreaResult,
+)
+from src.models.weather import (
+    LocationInfo,
+    CurrentWeather,
+    DailyForecastItem,
+    HourlyForecastItem,
+    NormalizedWeatherData,
+    ProviderSuccess,
+    ProviderError,
+    ProviderErrorDetail,
+    ProviderResult,
+    WeatherSummary,
+    SourceMeta,
+    AggregatedWeatherResponse,
+)
+
+__all__ = [
+    "GeoPoint",
+    "GeoBounds",
+    "TimeInfo",
+    "ProviderType",
+    "ErrorCode",
+    "PaginatedResult",
+    # Celestial
+    "CelestialPosition",
+    "RiseSet",
+    "MoonInfo",
+    "VisiblePlanet",
+    "ConstellationInfo",
+    "DeepSkyObject",
+    "NightlyForecast",
+    # Places
+    "LightPollutionGridPoint",
+    "LightPollutionGrid",
+    "StargazingLocation",
+    "AnalysisAreaResult",
+    # Weather
+    "LocationInfo",
+    "CurrentWeather",
+    "DailyForecastItem",
+    "HourlyForecastItem",
+    "NormalizedWeatherData",
+    "ProviderSuccess",
+    "ProviderError",
+    "ProviderErrorDetail",
+    "ProviderResult",
+    "WeatherSummary",
+    "SourceMeta",
+    "AggregatedWeatherResponse",
+]

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -1,0 +1,114 @@
+"""Core shared Pydantic models used across all domains."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class GeoPoint(BaseModel):
+    """A geographic coordinate point with latitude and longitude."""
+
+    lat: Annotated[
+        float,
+        Field(ge=-90.0, le=90.0, description="Latitude in decimal degrees"),
+    ]
+    lon: Annotated[
+        float,
+        Field(ge=-180.0, le=180.0, description="Longitude in decimal degrees"),
+    ]
+    elevation_m: Optional[float] = Field(
+        default=None, ge=0.0, description="Elevation in meters above sea level"
+    )
+
+    @field_validator("lat")
+    @classmethod
+    def _validate_lat(cls, v: float) -> float:
+        if not -90.0 <= v <= 90.0:
+            raise ValueError(f"Latitude must be between -90 and 90, got {v}")
+        return v
+
+    @field_validator("lon")
+    @classmethod
+    def _validate_lon(cls, v: float) -> float:
+        if not -180.0 <= v <= 180.0:
+            raise ValueError(f"Longitude must be between -180 and 180, got {v}")
+        return v
+
+
+class GeoBounds(BaseModel):
+    """A bounding box defined by south/west/north/east coordinates."""
+
+    south: Annotated[
+        float, Field(ge=-90.0, le=90.0, description="Southern latitude boundary")
+    ]
+    west: Annotated[
+        float,
+        Field(ge=-180.0, le=180.0, description="Western longitude boundary"),
+    ]
+    north: Annotated[
+        float, Field(ge=-90.0, le=90.0, description="Northern latitude boundary")
+    ]
+    east: Annotated[
+        float,
+        Field(ge=-180.0, le=180.0, description="Eastern longitude boundary"),
+    ]
+
+    @field_validator("north")
+    @classmethod
+    def _north_must_be_gte_south(cls, v: float, info) -> float:
+        if "south" in info.data and v < info.data["south"]:
+            raise ValueError(
+                f"north ({v}) must be >= south ({info.data['south']})"
+            )
+        return v
+
+    @field_validator("east")
+    @classmethod
+    def _east_must_be_gte_west(cls, v: float, info) -> float:
+        if "west" in info.data and v < info.data["west"]:
+            raise ValueError(
+                f"east ({v}) must be >= west ({info.data['west']})"
+            )
+        return v
+
+
+class TimeInfo(BaseModel):
+    """A timezone-aware datetime with its IANA timezone identifier."""
+
+    dt: datetime = Field(description="Timezone-aware datetime object")
+    timezone: str = Field(
+        description="IANA timezone identifier (e.g. 'Asia/Shanghai')"
+    )
+
+    @field_validator("dt")
+    @classmethod
+    def _dt_must_be_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError(
+                f"Datetime must be timezone-aware, got naive datetime: {v}"
+            )
+        return v
+
+
+class ProviderType(StrEnum):
+    """Supported weather provider types."""
+
+    ALL = "all"
+    OPEN_METEO = "open-meteo"
+    QWEATHER = "qweather"
+    WTTR = "wttr"
+
+    @classmethod
+    def from_str(cls, value: str) -> "ProviderType":
+        """Parse from string, case-insensitive."""
+        normalized = value.strip().lower()
+        for member in cls:
+            if member.value == normalized:
+                return member
+        raise ValueError(
+            f"Unknown provider: '{value}'. Allowed: {[m.value for m in cls]}"
+        )

--- a/src/models/celestial.py
+++ b/src/models/celestial.py
@@ -1,0 +1,68 @@
+"""Pydantic models for celestial (astronomy) domain data."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CelestialPosition(BaseModel):
+    """Altitude and azimuth of a celestial object."""
+
+    altitude: float = Field(description="Altitude above horizon in degrees (0°=horizon, 90°=zenith)")
+    azimuth: float = Field(description="Compass direction in degrees (0°=North, 90°=East)")
+
+
+class RiseSet(BaseModel):
+    """Rise and set times of a celestial object."""
+
+    rise_time: Optional[str] = Field(default=None, description="Rise time as ISO string (local timezone)")
+    set_time: Optional[str] = Field(default=None, description="Set time as ISO string (local timezone)")
+
+
+class MoonInfo(BaseModel):
+    """Detailed information about the Moon's phase and position."""
+
+    illumination: float = Field(description="Fraction of the moon illuminated (0.0 to 1.0)")
+    phase_name: str = Field(description="Phase description (e.g. 'Waxing Gibbous')")
+    age_days: float = Field(description="Approximate age of the moon in days since New Moon")
+    elongation: float = Field(description="Angular separation from Sun in degrees")
+    earth_distance: float = Field(description="Distance from Earth in km")
+
+
+class VisiblePlanet(BaseModel):
+    """A planet currently visible above the horizon."""
+
+    name: str = Field(description="Planet name")
+    altitude: float = Field(description="Altitude above horizon in degrees")
+    azimuth: float = Field(description="Compass direction in degrees")
+    constellation: Optional[str] = Field(default=None, description="Constellation the planet is in")
+
+
+class ConstellationInfo(BaseModel):
+    """Position of a constellation's center point."""
+
+    name: str = Field(description="Constellation name")
+    altitude: float = Field(description="Altitude above horizon in degrees")
+    azimuth: float = Field(description="Compass direction in degrees")
+
+
+class DeepSkyObject(BaseModel):
+    """A deep sky object (Messier/NGC) with viewing score."""
+
+    name: str = Field(description="Object name")
+    type: str = Field(description="Object type (galaxy, nebula, cluster, etc.)")
+    magnitude: float = Field(description="Apparent magnitude")
+    altitude: float = Field(description="Altitude above horizon in degrees")
+    azimuth: float = Field(description="Compass direction in degrees")
+    catalog: str = Field(description="Catalog identifier (Messier, NGC, etc.)")
+    score: float = Field(description="Viewing score (lower is better)")
+
+
+class NightlyForecast(BaseModel):
+    """Curated list of best objects to view for a given night."""
+
+    moon_phase: MoonInfo = Field(description="Moon phase details")
+    planets: List[VisiblePlanet] = Field(default_factory=list, description="Visible planets")
+    deep_sky: List[DeepSkyObject] = Field(default_factory=list, description="Recommended deep sky objects")

--- a/src/models/error.py
+++ b/src/models/error.py
@@ -1,0 +1,21 @@
+"""Standard error codes for the MCP Stargazing server.
+
+Maps to the existing MCPError codes in src/response.py.
+"""
+
+from enum import StrEnum
+
+
+class ErrorCode(StrEnum):
+    """Standardized error codes for structured error responses."""
+
+    INVALID_COORDINATES = "INVALID_COORDINATES"
+    INVALID_TIMEZONE = "INVALID_TIMEZONE"
+    INVALID_TIME_FORMAT = "INVALID_TIME_FORMAT"
+    MISSING_API_KEY = "MISSING_API_KEY"
+    API_AUTH_FAILURE = "API_AUTH_FAILURE"
+    API_TIMEOUT = "API_TIMEOUT"
+    API_RATE_LIMIT = "API_RATE_LIMIT"
+    EXTERNAL_API_ERROR = "EXTERNAL_API_ERROR"
+    NETWORK_ERROR = "NETWORK_ERROR"
+    CONFIGURATION_ERROR = "CONFIGURATION_ERROR"

--- a/src/models/pagination.py
+++ b/src/models/pagination.py
@@ -1,0 +1,29 @@
+"""Generic paginated result model."""
+
+from __future__ import annotations
+
+from typing import Generic, List, TypeVar
+
+from pydantic import BaseModel, Field
+
+T = TypeVar("T")
+
+
+class PaginatedResult(BaseModel, Generic[T]):
+    """A generic paginated result container.
+
+    Usage:
+        result = PaginatedResult[MyModel](
+            items=[...], total=42, page=1, page_size=10
+        )
+        result.model_dump()  # serializes with typed items
+    """
+
+    items: List[T] = Field(description="Paginated items for the current page")
+    total: int = Field(ge=0, description="Total number of items across all pages")
+    page: int = Field(ge=1, description="Current page number (1-based)")
+    page_size: int = Field(ge=1, description="Number of items per page")
+    total_pages: int = Field(ge=0, description="Total number of pages")
+    resource_id: str | None = Field(
+        default=None, description="Optional cache/resource identifier"
+    )

--- a/src/models/places.py
+++ b/src/models/places.py
@@ -1,0 +1,49 @@
+"""Pydantic models for places / stargazing location domain."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LightPollutionGridPoint(BaseModel):
+    """A single data point in a light pollution grid."""
+
+    lat: float = Field(description="Latitude of the grid point")
+    lon: float = Field(description="Longitude of the grid point")
+    brightness: Optional[float] = Field(default=None, description="Brightness value (nanoWatts/cm²/sr)")
+    bortle: Optional[int] = Field(default=None, description="Bortle class (1-9, lower is darker)")
+    sqm: Optional[float] = Field(default=None, description="Sky Quality Meter value (mag/arcsec²)")
+
+
+class LightPollutionGrid(BaseModel):
+    """Light pollution data for a geographic area."""
+
+    grid: List[LightPollutionGridPoint] = Field(default_factory=list, description="Grid data points")
+    bounds: Dict[str, float] = Field(description="Bounding box: south, west, north, east")
+    zoom: int = Field(description="Zoom level used for the grid resolution")
+
+
+class StargazingLocation(BaseModel):
+    """A stargazing location with analysis results."""
+
+    name: Optional[str] = Field(default=None, description="Location name or identifier")
+    lat: float = Field(description="Latitude in decimal degrees")
+    lon: float = Field(description="Longitude in decimal degrees")
+    elevation_m: Optional[float] = Field(default=None, description="Elevation in meters")
+    light_pollution_level: Optional[str] = Field(default=None, description="Light pollution description")
+    bortle_class: Optional[int] = Field(default=None, description="Bortle class (1-9)")
+    road_distance_km: Optional[float] = Field(default=None, description="Distance to nearest road in km")
+    score: Optional[float] = Field(default=None, description="Overall stargazing suitability score")
+
+
+class AnalysisAreaResult(BaseModel):
+    """Paginated result of stargazing location analysis."""
+
+    items: List[StargazingLocation] = Field(description="Location results for the current page")
+    total: int = Field(ge=0, description="Total number of locations found")
+    page: int = Field(ge=1, description="Current page number (1-based)")
+    page_size: int = Field(ge=1, description="Number of results per page")
+    total_pages: int = Field(ge=0, description="Total number of pages")
+    resource_id: str = Field(description="Cache key for these search parameters")

--- a/src/models/weather.py
+++ b/src/models/weather.py
@@ -1,0 +1,146 @@
+"""Pydantic models for weather domain data.
+
+Replaces the dict-based builder functions in src/functions/weather/models.py
+with type-safe, validated Pydantic models.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from src.models.base import GeoPoint
+
+
+# ── Location ──────────────────────────────────────────────────────────────
+
+class LocationInfo(BaseModel):
+    """Normalized location information for weather results."""
+
+    name: Optional[str] = Field(default=None, description="Human-readable place name")
+    lat: float = Field(description="Latitude in decimal degrees")
+    lon: float = Field(description="Longitude in decimal degrees")
+    timezone: Optional[str] = Field(default=None, description="IANA timezone string")
+
+
+# ── Current Weather ───────────────────────────────────────────────────────
+
+class CurrentWeather(BaseModel):
+    """Current weather conditions at a specific point in time."""
+
+    temperature_c: Optional[float] = Field(default=None, description="Current temperature in Celsius")
+    feels_like_c: Optional[float] = Field(default=None, description="Apparent temperature in Celsius")
+    humidity: Optional[float] = Field(default=None, description="Relative humidity in percent")
+    wind_speed_kph: Optional[float] = Field(default=None, description="Wind speed in km/h")
+    wind_direction_deg: Optional[float] = Field(default=None, description="Wind direction in degrees")
+    pressure_hpa: Optional[float] = Field(default=None, description="Atmospheric pressure in hPa")
+    visibility_km: Optional[float] = Field(default=None, description="Visibility in km")
+    cloud_cover_percent: Optional[float] = Field(default=None, description="Total cloud cover in percent")
+    cloud_cover_low_percent: Optional[float] = Field(default=None, description="Low-level cloud cover in percent")
+    cloud_cover_mid_percent: Optional[float] = Field(default=None, description="Mid-level cloud cover in percent")
+    cloud_cover_high_percent: Optional[float] = Field(default=None, description="High-level cloud cover in percent")
+    weather_code: Optional[str] = Field(default=None, description="Internal unified weather code (clear, rain, snow, etc.)")
+    weather_text: Optional[str] = Field(default=None, description="Human-readable weather description")
+    observation_time: Optional[str] = Field(default=None, description="Observation time string")
+
+
+# ── Forecast Items ────────────────────────────────────────────────────────
+
+class DailyForecastItem(BaseModel):
+    """A single day's weather forecast."""
+
+    date: str = Field(description="Date string (YYYY-MM-DD)")
+    temp_min_c: Optional[float] = Field(default=None, description="Minimum temperature in Celsius")
+    temp_max_c: Optional[float] = Field(default=None, description="Maximum temperature in Celsius")
+    precipitation_probability: Optional[float] = Field(default=None, description="Precipitation probability (0.0–1.0)")
+    cloud_cover_percent: Optional[float] = Field(default=None, description="Cloud cover in percent")
+    weather_code_day: Optional[str] = Field(default=None, description="Internal unified weather code for daytime")
+    weather_text_day: Optional[str] = Field(default=None, description="Human-readable daytime weather description")
+
+
+class HourlyForecastItem(BaseModel):
+    """A single hour's weather forecast."""
+
+    time: str = Field(description="Time string (ISO format or YYYY-MM-DDTHH:MM:SS)")
+    temperature_c: Optional[float] = Field(default=None, description="Temperature in Celsius")
+    humidity: Optional[float] = Field(default=None, description="Relative humidity in percent")
+    precipitation_probability: Optional[float] = Field(default=None, description="Precipitation probability (0.0–1.0)")
+    wind_speed_kph: Optional[float] = Field(default=None, description="Wind speed in km/h")
+    wind_direction_deg: Optional[float] = Field(default=None, description="Wind direction in degrees")
+    cloud_cover_percent: Optional[float] = Field(default=None, description="Total cloud cover in percent")
+    cloud_cover_low_percent: Optional[float] = Field(default=None, description="Low-level cloud cover in percent")
+    cloud_cover_mid_percent: Optional[float] = Field(default=None, description="Mid-level cloud cover in percent")
+    cloud_cover_high_percent: Optional[float] = Field(default=None, description="High-level cloud cover in percent")
+    weather_code: Optional[str] = Field(default=None, description="Internal unified weather code")
+    weather_text: Optional[str] = Field(default=None, description="Human-readable weather description")
+
+
+# ── Provider Results ──────────────────────────────────────────────────────
+
+class NormalizedWeatherData(BaseModel):
+    """The normalized weather data returned by a single provider."""
+
+    location: LocationInfo = Field(description="Resolved location information")
+    current: CurrentWeather = Field(description="Current weather conditions")
+    daily: List[DailyForecastItem] = Field(default_factory=list, description="Daily forecast list")
+    hourly: List[HourlyForecastItem] = Field(default_factory=list, description="Hourly forecast list")
+
+
+class ProviderSuccess(BaseModel):
+    """A successful provider query result."""
+
+    status: str = Field(default="success", description="Status indicator")
+    provider: str = Field(description="Provider name")
+    data: NormalizedWeatherData = Field(description="Normalized weather data from this provider")
+
+
+class ProviderErrorDetail(BaseModel):
+    """Details of a provider error."""
+
+    code: str = Field(description="Error code")
+    message: str = Field(description="Error message")
+    details: Optional[Dict[str, Any]] = Field(default=None, description="Additional error context")
+
+
+class ProviderError(BaseModel):
+    """A failed provider query result."""
+
+    status: str = Field(default="error", description="Status indicator")
+    provider: str = Field(description="Provider name")
+    error: ProviderErrorDetail = Field(description="Error details")
+
+
+ProviderResult = ProviderSuccess | ProviderError
+"""Union type for provider query results (success or error)."""
+
+
+# ── Aggregated Response ───────────────────────────────────────────────────
+
+class WeatherSummary(BaseModel):
+    """Merged weather summary from multiple providers."""
+
+    current: Dict[str, Any] = Field(default_factory=dict, description="Merged current weather (field-level fallback)")
+    daily: List[Dict[str, Any]] = Field(default_factory=list, description="Daily forecast from primary provider")
+    hourly: List[Dict[str, Any]] = Field(default_factory=list, description="Hourly forecast from primary provider")
+
+
+class SourceMeta(BaseModel):
+    """Metadata about which providers were used for the aggregated result."""
+
+    query_mode: str = Field(description="The original provider filter requested")
+    successful_providers: List[str] = Field(default_factory=list, description="Providers that returned data")
+    failed_providers: List[str] = Field(default_factory=list, description="Providers that failed")
+    summary_provider_policy: str = Field(default="open-meteo-first", description="Policy used to select summary provider")
+
+
+class AggregatedWeatherResponse(BaseModel):
+    """The top-level aggregated weather response."""
+
+    location: LocationInfo = Field(description="Resolved location")
+    summary: WeatherSummary = Field(description="Merged weather summary")
+    providers: Dict[str, ProviderResult] = Field(
+        description="Per-provider raw results (success or error)"
+    )
+    source: SourceMeta = Field(description="Provider source metadata")

--- a/tests/test_pydantic_models.py
+++ b/tests/test_pydantic_models.py
@@ -1,0 +1,225 @@
+"""Tests for Pydantic model validation behavior."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.models import (
+    GeoPoint,
+    GeoBounds,
+    CelestialPosition,
+    MoonInfo,
+    VisiblePlanet,
+    NightlyForecast,
+    DeepSkyObject,
+    LightPollutionGridPoint,
+    StargazingLocation,
+    AnalysisAreaResult,
+    ProviderSuccess,
+    ProviderError,
+    NormalizedWeatherData,
+    LocationInfo,
+    CurrentWeather,
+    AggregatedWeatherResponse,
+)
+
+
+# ── Base Models ─────────────────────────────────────────────────────────────
+
+class TestGeoPoint:
+    def test_valid_coordinates(self):
+        point = GeoPoint(lat=45.5, lon=-73.5)
+        assert point.lat == 45.5
+        assert point.lon == -73.5
+
+    def test_invalid_latitude(self):
+        with pytest.raises(ValidationError):
+            GeoPoint(lat=100, lon=0)
+
+    def test_invalid_longitude(self):
+        with pytest.raises(ValidationError):
+            GeoPoint(lat=0, lon=-200)
+
+
+class TestGeoBounds:
+    def test_valid_bounds(self):
+        bounds = GeoBounds(south=-10, west=-20, north=10, east=20)
+        assert bounds.south == -10
+
+    def test_invalid_bounds_south_greater_than_north(self):
+        with pytest.raises(ValidationError):
+            GeoBounds(south=10, west=0, north=5, east=20)
+
+    def test_invalid_bounds_west_greater_than_east(self):
+        with pytest.raises(ValidationError):
+            GeoBounds(south=0, west=20, north=10, east=10)
+
+
+# ── Celestial Models ────────────────────────────────────────────────────────
+
+class TestCelestialPosition:
+    def test_valid_position(self):
+        pos = CelestialPosition(altitude=45.0, azimuth=180.0)
+        assert pos.altitude == 45.0
+        assert pos.azimuth == 180.0
+
+    def test_missing_field(self):
+        with pytest.raises(ValidationError):
+            CelestialPosition(altitude=45.0)  # missing azimuth
+
+
+class TestMoonInfo:
+    def test_valid_moon_info(self):
+        info = MoonInfo(
+            illumination=0.5,
+            phase_name="First Quarter",
+            age_days=7.4,
+            elongation=90.0,
+            earth_distance=384400.0,
+        )
+        assert info.phase_name == "First Quarter"
+
+    def test_invalid_illumination_coerced(self):
+        # Pydantic will accept int and coerce to float
+        info = MoonInfo(
+            illumination=1,
+            phase_name="Full Moon",
+            age_days=14.8,
+            elongation=180.0,
+            earth_distance=384400.0,
+        )
+        assert isinstance(info.illumination, float)
+
+
+class TestNightlyForecast:
+    def test_valid_forecast(self):
+        forecast = NightlyForecast(
+            moon_phase=MoonInfo(
+                illumination=0.5, phase_name="First Quarter",
+                age_days=7.4, elongation=90.0, earth_distance=384400.0,
+            ),
+            planets=[VisiblePlanet(name="Mars", altitude=30.0, azimuth=90.0)],
+            deep_sky=[DeepSkyObject(
+                name="M42", type="Nebula", magnitude=4.0,
+                altitude=45.0, azimuth=120.0, catalog="Messier", score=2.5,
+            )],
+        )
+        assert len(forecast.planets) == 1
+        assert forecast.planets[0].name == "Mars"
+        assert len(forecast.deep_sky) == 1
+        assert forecast.deep_sky[0].name == "M42"
+
+    def test_empty_forecast(self):
+        forecast = NightlyForecast(
+            moon_phase=MoonInfo(
+                illumination=0.0, phase_name="New Moon",
+                age_days=0.0, elongation=0.0, earth_distance=384400.0,
+            ),
+        )
+        assert forecast.planets == []
+        assert forecast.deep_sky == []
+
+
+# ── Places Models ───────────────────────────────────────────────────────────
+
+class TestLightPollutionGridPoint:
+    def test_valid_grid_point(self):
+        point = LightPollutionGridPoint(lat=35.0, lon=-120.0, bortle=4, sqm=21.5)
+        assert point.bortle == 4
+        assert point.sqm == 21.5
+
+    def test_minimal_grid_point(self):
+        point = LightPollutionGridPoint(lat=0.0, lon=0.0)
+        assert point.brightness is None
+
+
+class TestStargazingLocation:
+    def test_valid_location(self):
+        loc = StargazingLocation(
+            name="Test Site", lat=35.0, lon=-120.0,
+            elevation_m=1500.0, bortle_class=2,
+        )
+        assert loc.name == "Test Site"
+        assert loc.bortle_class == 2
+
+    def test_minimal_location(self):
+        loc = StargazingLocation(lat=0.0, lon=0.0)
+        assert loc.name is None
+
+
+class TestAnalysisAreaResult:
+    def test_valid_result(self):
+        result = AnalysisAreaResult(
+            items=[StargazingLocation(lat=35.0, lon=-120.0)],
+            total=1, page=1, page_size=10, total_pages=1,
+            resource_id="abc123",
+        )
+        assert len(result.items) == 1
+        assert result.total_pages == 1
+
+    def test_page_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            AnalysisAreaResult(
+                items=[], total=0, page=0, page_size=10, total_pages=0,
+                resource_id="abc",
+            )
+
+    def test_total_must_be_non_negative(self):
+        with pytest.raises(ValidationError):
+            AnalysisAreaResult(
+                items=[], total=-1, page=1, page_size=10, total_pages=0,
+                resource_id="abc",
+            )
+
+
+# ── Weather Models ──────────────────────────────────────────────────────────
+
+class TestAggregatedWeatherResponse:
+    def test_providers_accepts_typed_models(self):
+        """Test that providers field accepts ProviderSuccess/ProviderError directly."""
+        loc = LocationInfo(name="Test", lat=0.0, lon=0.0)
+        current = CurrentWeather(temperature_c=20.0)
+        data = NormalizedWeatherData(location=loc, current=current)
+        success = ProviderSuccess(provider="open-meteo", data=data)
+        error = ProviderError(
+            provider="qweather",
+            error={"code": "API_ERROR", "message": "Failed"},
+        )
+
+        response = AggregatedWeatherResponse(
+            location=loc,
+            summary={"current": {}, "daily": [], "hourly": []},
+            providers={"open-meteo": success, "qweather": error},
+            source={
+                "query_mode": "all",
+                "successful_providers": ["open-meteo"],
+                "failed_providers": ["qweather"],
+            },
+        )
+        assert isinstance(response.providers["open-meteo"], ProviderSuccess)
+        assert isinstance(response.providers["qweather"], ProviderError)
+        # Verify serialization works recursively
+        dumped = response.model_dump()
+        assert dumped["providers"]["open-meteo"]["status"] == "success"
+        assert dumped["providers"]["qweather"]["status"] == "error"
+
+    def test_model_dump_roundtrip(self):
+        """Test that model_dump produces a JSON-serializable dict."""
+        loc = LocationInfo(name="Paris", lat=48.86, lon=2.35)
+        current = CurrentWeather(temperature_c=15.0)
+        data = NormalizedWeatherData(location=loc, current=current)
+        success = ProviderSuccess(provider="open-meteo", data=data)
+
+        response = AggregatedWeatherResponse(
+            location=loc,
+            summary={"current": {"temperature_c": 15.0}, "daily": [], "hourly": []},
+            providers={"open-meteo": success},
+            source={
+                "query_mode": "all",
+                "successful_providers": ["open-meteo"],
+                "failed_providers": [],
+            },
+        )
+        dumped = response.model_dump()
+        import json
+        # Should not raise
+        json.dumps(dumped)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -86,7 +86,7 @@ def test_analysis_area_pagination_serialization():
              patch('src.functions.places.impl.ANALYSIS_CACHE', new=MockCache()) as mock_cache: 
             
             mock_instance = MockPF.return_value
-            mock_results = [{"name": f"Loc {i}", "score": i} for i in range(25)]
+            mock_results = [{"name": f"Loc {i}", "score": i, "lat": 35.0 + i * 0.01, "lon": -120.0 - i * 0.01} for i in range(25)]
             mock_instance.analyze_area.return_value = mock_results
             
             # Test Page 1 (size 10)

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -20,4 +20,4 @@ def test_tool_catalog_contains_registered_tools():
     assert celestial_tool['description'] == 'Calculate the altitude and azimuth angles of a celestial object.'
     assert any(param['name'] == 'lat' for param in celestial_tool['parameters'])
     assert any(param['name'] == 'time_zone' for param in celestial_tool['parameters'])
-    assert 'Dict' in celestial_tool['return_type']
+    assert 'dict' in celestial_tool['return_type'] or 'Dict' in celestial_tool['return_type']

--- a/tests/test_weather_service.py
+++ b/tests/test_weather_service.py
@@ -1,56 +1,62 @@
 from unittest.mock import patch
 
 from src.functions.weather.service import get_aggregated_weather_by_position
+from src.models.weather import (
+    CurrentWeather,
+    DailyForecastItem,
+    HourlyForecastItem,
+    LocationInfo,
+    NormalizedWeatherData,
+    ProviderError,
+    ProviderSuccess,
+)
 
 
 def test_aggregated_weather_by_position_uses_open_meteo_hourly_first():
-    open_meteo_result = {
-        "status": "success",
-        "provider": "open-meteo",
-        "data": {
-            "location": {"name": "Beijing", "lat": 39.9, "lon": 116.4, "timezone": "Asia/Shanghai"},
-            "current": {"temperature_c": 25.0, "cloud_cover_percent": 60.0},
-            "daily": [{"date": "2026-06-15", "cloud_cover_percent": 65.0}],
-            "hourly": [{"time": "2026-06-15T10:00:00+08:00", "cloud_cover_percent": 55.0}],
-        },
-    }
-    wttr_result = {
-        "status": "success",
-        "provider": "wttr",
-        "data": {
-            "location": {"name": "Beijing", "lat": 39.9, "lon": 116.4, "timezone": None},
-            "current": {"temperature_c": 24.0, "cloud_cover_percent": 45.0},
-            "daily": [{"date": "2026-06-15", "cloud_cover_percent": 50.0}],
-            "hourly": [{"time": "2026-06-15T10:00:00+08:00", "cloud_cover_percent": 40.0}],
-        },
-    }
+    open_meteo_result = ProviderSuccess(
+        provider="open-meteo",
+        data=NormalizedWeatherData(
+            location=LocationInfo(name="Beijing", lat=39.9, lon=116.4, timezone="Asia/Shanghai"),
+            current=CurrentWeather(temperature_c=25.0, cloud_cover_percent=60.0),
+            daily=[DailyForecastItem(date="2026-06-15", cloud_cover_percent=65.0)],
+            hourly=[HourlyForecastItem(time="2026-06-15T10:00:00+08:00", cloud_cover_percent=55.0)],
+        ),
+    )
+    wttr_result = ProviderSuccess(
+        provider="wttr",
+        data=NormalizedWeatherData(
+            location=LocationInfo(name="Beijing", lat=39.9, lon=116.4, timezone=None),
+            current=CurrentWeather(temperature_c=24.0, cloud_cover_percent=45.0),
+            daily=[DailyForecastItem(date="2026-06-15", cloud_cover_percent=50.0)],
+            hourly=[HourlyForecastItem(time="2026-06-15T10:00:00+08:00", cloud_cover_percent=40.0)],
+        ),
+    )
 
     with patch("src.functions.weather.service.open_meteo.get_weather_by_position", return_value=open_meteo_result), \
          patch("src.functions.weather.service.qweather.get_weather_by_position", side_effect=Exception("should not be called")), \
          patch("src.functions.weather.service.wttr.get_weather_by_position", return_value=wttr_result):
         result = get_aggregated_weather_by_position(39.9, 116.4, provider="all", location_name="Beijing")
 
-    assert result["summary"]["current"]["temperature_c"] == 25.0
-    assert result["summary"]["hourly"][0]["cloud_cover_percent"] == 55.0
-    assert result["source"]["successful_providers"] == ["open-meteo", "wttr"]
+    assert result.summary.current["temperature_c"] == 25.0
+    assert result.summary.hourly[0]["cloud_cover_percent"] == 55.0
+    assert result.source.successful_providers == ["open-meteo", "wttr"]
 
 
 def test_aggregated_weather_by_position_keeps_partial_provider_failures():
-    open_meteo_result = {
-        "status": "success",
-        "provider": "open-meteo",
-        "data": {
-            "location": {"name": None, "lat": 40.0, "lon": 116.0, "timezone": "Asia/Shanghai"},
-            "current": {"temperature_c": 22.0, "cloud_cover_percent": 35.0},
-            "daily": [],
-            "hourly": [],
-        },
-    }
+    open_meteo_result = ProviderSuccess(
+        provider="open-meteo",
+        data=NormalizedWeatherData(
+            location=LocationInfo(name=None, lat=40.0, lon=116.0, timezone="Asia/Shanghai"),
+            current=CurrentWeather(temperature_c=22.0, cloud_cover_percent=35.0),
+            daily=[],
+            hourly=[],
+        ),
+    )
 
     with patch("src.functions.weather.service.open_meteo.get_weather_by_position", return_value=open_meteo_result), \
          patch("src.functions.weather.service.qweather.get_weather_by_position", side_effect=Exception("qweather down")), \
          patch("src.functions.weather.service.wttr.get_weather_by_position", side_effect=Exception("wttr down")):
         result = get_aggregated_weather_by_position(40.0, 116.0, provider="all")
 
-    assert result["summary"]["current"]["cloud_cover_percent"] == 35.0
-    assert set(result["source"]["failed_providers"]) == {"qweather", "wttr"}
+    assert result.summary.current["cloud_cover_percent"] == 35.0
+    assert set(result.source.failed_providers) == {"qweather", "wttr"}


### PR DESCRIPTION
## Summary

Complete migration from ad-hoc dict-based data passing to Pydantic models across all domains (celestial, places, weather). This enforces type-safe interfaces between modules and functions.

## Changes

- Celestial domain: 7 new models (CelestialPosition, RiseSet, MoonInfo, etc.)
- Places domain: 4 new models (LightPollutionGridPoint, StargazingLocation, etc.)
- Weather: AggregatedWeatherResponse.providers now properly typed as Dict[str, ProviderResult]
- Input validation: replaced manual _validate_coordinates / _validate_provider with Pydantic GeoPoint + WeatherQuery
- Tests: 21 new Pydantic validation tests

## Testing

All 66 tests pass.