### PR TITLE
Add Bandit static security analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run ruff format check
         run: uv run ruff format --check src/ tests/
 
+      - name: Run bandit security check
+        run: uv run bandit -c pyproject.toml -r src/
+
   test:
     name: Docker Build and Test
     needs: lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,11 @@ repos:
         types_or: [python, pyi]
       - id: ruff-format
         types_or: [python, pyi]
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.3
+    hooks:
+      - id: bandit
+        args: [-c, pyproject.toml]
+        additional_dependencies: [".[dev]"]
+        files: ^src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,13 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "ruff>=0.11.0",
     "pre-commit>=4.0.0",
+    "bandit>=1.8.0",
 ]
+
+[tool.bandit]
+targets = ["src/", "tests/"]
+skips = ["B101"]
+assert_used = false
 
 [tool.ruff]
 target-version = "py313"

--- a/src/cache.py
+++ b/src/cache.py
@@ -37,4 +37,4 @@ def generate_cache_key(**kwargs) -> str:
     """Generate a stable cache key from arguments."""
     # Sort keys to ensure stability
     serialized = json.dumps(kwargs, sort_keys=True, default=str)
-    return hashlib.md5(serialized.encode()).hexdigest()
+    return hashlib.md5(serialized.encode(), usedforsecurity=False).hexdigest()

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@ def arg_parse():
 def main():
     """Run the MCP server."""
     arg = arg_parse()
-    host = os.getenv('MCP_HOST', '0.0.0.0')
+    host = os.getenv('MCP_HOST', '0.0.0.0')  # nosec - intentional MCP server bind
     auto_env = os.getenv('ASTROPY_IERS_AUTO_DOWNLOAD', '0')
     iers_conf.auto_download = auto_env == '1'
     iers_conf.auto_max_age = None

--- a/uv.lock
+++ b/uv.lock
@@ -345,6 +345,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677 }
+wheels = [
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741 },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.5"
 source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
@@ -1787,6 +1802,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1809,6 +1825,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.8.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -3322,6 +3339,15 @@ dependencies = [
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985 }
 wheels = [
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033 },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710 }
+wheels = [
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds [Bandit](https://github.com/PyCQA/bandit) static security analysis to the project's toolchain.

## Changes

- **pyproject.toml**: Add bandit dev dependency and [tool.bandit] config (skip B101 assert tests, target src/ and tests/)
- **.pre-commit-config.yaml**: Add bandit hook (PyCQA/bandit v1.8.3) for src/ only
- **.github/workflows/ci.yml**: Add bandit scan step in lint job
- **src/cache.py**: Fix B324 - specify `usedforsecurity=False` for cache key MD5 hash
- **src/main.py**: Fix B104 - mark intentional `0.0.0.0` bind with `# nosec`

## Verification

- `bandit -c pyproject.toml -r src/` passes clean (0 issues)
- All 66 existing tests pass