### PR TITLE
fix: lightpollution & analysis PostGIS tool issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "rasterio",
     "tzlocal",
     "geopy",
-    "stargazing-place-finder>=0.6.0,<1",
+    "stargazing-place-finder>=0.6.3,<1",
 ]
 
 [project.scripts]

--- a/src/functions/places/impl.py
+++ b/src/functions/places/impl.py
@@ -32,7 +32,7 @@ async def light_pollution_map(
 
     raw = await asyncio.to_thread(_compute)
     grid = LightPollutionGrid(
-        grid=[LightPollutionGridPoint(**p) for p in raw.get('grid', [])],
+        grid=[LightPollutionGridPoint.from_spf_point(p) for p in raw.get('data', [])],
         bounds={'south': south, 'west': west, 'north': north, 'east': east},
         zoom=zoom,
     )
@@ -109,10 +109,8 @@ async def analysis_area(
                 max_locations=max_locations,
                 network_type=network_type,
             )
-            # Convert raw dict results to StargazingLocation models
-            return [
-                StargazingLocation(**item) if isinstance(item, dict) else item for item in results
-            ]
+            # Convert spf StargazingLocation objects to our models
+            return [StargazingLocation.from_spf_location(item) for item in results]
 
         cached = await asyncio.to_thread(_compute)
         ANALYSIS_CACHE.set(resource_id, cached)

--- a/src/functions/weather/impl.py
+++ b/src/functions/weather/impl.py
@@ -7,7 +7,7 @@ from src.functions.weather.service import (
 )
 from src.models import GeoPoint
 from src.models.weather import AggregatedWeatherResponse
-from src.response import MCPError, format_response
+from src.response import MCPError, format_error, format_response
 from src.retry import RetryConfig, retry_on_failure
 from src.server_instance import mcp
 
@@ -38,33 +38,53 @@ def get_weather_by_name(place_name: str, provider: str = 'all'):
     """
     通过地点名称获取综合天气（当前 + 小时预报 + 日预报）。
 
+    Geocoding uses Nominatim (free).  Weather data is aggregated from
+    multiple providers with graceful fallback — open-meteo is always
+    available without an API key.
+
     Args:
         place_name: 地点名称（例如城市/区县）。
         provider: provider 模式，可选 all/qweather/open-meteo/wttr。
 
     Returns:
-        Dict，包含 keys: "data", "_meta"。
-
-    Raises:
-        MCPError: For validation failures, API errors, or network issues.
+        Dict，包含 keys: "data", "_meta"（成功时）或 "error", "_meta"（失败时）。
     """
     cleaned_name = place_name.strip()
     if not cleaned_name:
-        raise MCPError(
+        return format_error(
             MCPError.CONFIGURATION_ERROR,
             'place_name 不能为空。',
             {'place_name': place_name},
         )
-    WeatherQuery(provider=provider)  # validates via Pydantic
 
-    @retry_on_failure(
-        RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
-        retryable_errors=(ConnectionError, TimeoutError, OSError),
-    )
-    def _fetch_weather():
-        return get_aggregated_weather_by_name(cleaned_name, provider=provider)
+    try:
+        WeatherQuery(provider=provider)  # validates via Pydantic
+    except ValueError as exc:
+        return format_error(
+            MCPError.CONFIGURATION_ERROR,
+            str(exc),
+            {'place_name': cleaned_name, 'provider': provider},
+        )
 
-    result = _fetch_weather()
+    try:
+
+        @retry_on_failure(
+            RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
+            retryable_errors=(ConnectionError, TimeoutError, OSError),
+        )
+        def _fetch_weather():
+            return get_aggregated_weather_by_name(cleaned_name, provider=provider)
+
+        result = _fetch_weather()
+    except MCPError as exc:
+        return exc.to_response()
+    except Exception as exc:
+        return format_error(
+            MCPError.EXTERNAL_API_ERROR,
+            f'天气查询失败: {exc}',
+            {'place_name': cleaned_name},
+        )
+
     if isinstance(result, AggregatedWeatherResponse):
         return format_response(result.model_dump())
     return format_response(result)
@@ -75,28 +95,54 @@ def get_weather_by_position(lat: float, lon: float, provider: str = 'all'):
     """
     通过经纬度获取综合天气（当前 + 小时预报 + 日预报）。
 
+    Weather data is aggregated from multiple providers with graceful
+    fallback — open-meteo is always available without an API key.
+
     Args:
         lat: 纬度
         lon: 经度
         provider: provider 模式，可选 all/qweather/open-meteo/wttr。
 
     Returns:
-        Dict，包含 keys: "data", "_meta"。
-
-    Raises:
-        MCPError: For validation failures, API errors, or network issues.
+        Dict，包含 keys: "data", "_meta"（成功时）或 "error", "_meta"（失败时）。
     """
-    GeoPoint(lat=lat, lon=lon)  # validates via Pydantic
-    WeatherQuery(provider=provider)  # validates via Pydantic
+    try:
+        GeoPoint(lat=lat, lon=lon)  # validates via Pydantic
+    except ValueError as exc:
+        return format_error(
+            MCPError.INVALID_COORDINATES,
+            str(exc),
+            {'lat': lat, 'lon': lon},
+        )
 
-    @retry_on_failure(
-        RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
-        retryable_errors=(ConnectionError, TimeoutError, OSError),
-    )
-    def _fetch_weather():
-        return get_aggregated_weather_by_position(lat, lon, provider=provider)
+    try:
+        WeatherQuery(provider=provider)  # validates via Pydantic
+    except ValueError as exc:
+        return format_error(
+            MCPError.CONFIGURATION_ERROR,
+            str(exc),
+            {'lat': lat, 'lon': lon, 'provider': provider},
+        )
 
-    result = _fetch_weather()
+    try:
+
+        @retry_on_failure(
+            RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
+            retryable_errors=(ConnectionError, TimeoutError, OSError),
+        )
+        def _fetch_weather():
+            return get_aggregated_weather_by_position(lat, lon, provider=provider)
+
+        result = _fetch_weather()
+    except MCPError as exc:
+        return exc.to_response()
+    except Exception as exc:
+        return format_error(
+            MCPError.EXTERNAL_API_ERROR,
+            f'天气查询失败: {exc}',
+            {'lat': lat, 'lon': lon},
+        )
+
     if isinstance(result, AggregatedWeatherResponse):
         return format_response(result.model_dump())
     return format_response(result)

--- a/src/models/places.py
+++ b/src/models/places.py
@@ -15,6 +15,30 @@ class LightPollutionGridPoint(BaseModel):
     )
     bortle: int | None = Field(default=None, description='Bortle class (1-9, lower is darker)')
     sqm: float | None = Field(default=None, description='Sky Quality Meter value (mag/arcsec²)')
+    intensity: float | None = Field(default=None, description='Normalized intensity (0-1)')
+    radiance: float | None = Field(default=None, description='Radiance value (nW/cm²/sr)')
+    rgb: list[int] | None = Field(default=None, description='RGB color tuple')
+    hex: str | None = Field(default=None, description='Hex color string')
+    name: str | None = Field(default=None, description='Point label')
+    overlay_name: str | None = Field(default=None, description='Data source overlay name')
+
+    @classmethod
+    def from_spf_point(cls, point: dict) -> LightPollutionGridPoint:
+        """Build from a stargazingplacefinder raw grid point dict."""
+        sqm_raw = point.get('sqm')
+        return cls(
+            lat=float(point['lat']),
+            lon=float(point.get('lng', point.get('lon', 0))),
+            brightness=point.get('brightness'),
+            bortle=point.get('bortle'),
+            sqm=float(sqm_raw) if sqm_raw is not None else None,
+            intensity=point.get('intensity'),
+            radiance=point.get('radiance'),
+            rgb=point.get('rgb'),
+            hex=point.get('hex'),
+            name=point.get('name'),
+            overlay_name=point.get('overlay_name'),
+        )
 
 
 class LightPollutionGrid(BaseModel):
@@ -42,6 +66,27 @@ class StargazingLocation(BaseModel):
         default=None, description='Distance to nearest road in km'
     )
     score: float | None = Field(default=None, description='Overall stargazing suitability score')
+
+    @classmethod
+    def from_spf_location(cls, loc) -> StargazingLocation:
+        """Build from a stargazingplacefinder StargazingLocation object."""
+        # spf model uses pydantic — try model_dump() first, fall back to dict access
+        if hasattr(loc, 'model_dump'):
+            d = loc.model_dump(exclude_none=True)
+        elif hasattr(loc, 'dict'):
+            d = loc.dict(exclude_none=True)
+        else:
+            d = dict(loc)
+        return cls(
+            name=d.get('name'),
+            lat=d.get('latitude', d.get('lat')),
+            lon=d.get('longitude', d.get('lon')),
+            elevation_m=d.get('elevation'),
+            light_pollution_level=d.get('light_pollution_level'),
+            bortle_class=d.get('light_pollution_bortle'),
+            road_distance_km=d.get('distance_to_road_km'),
+            score=d.get('stargazing_score'),
+        )
 
 
 class AnalysisAreaResult(BaseModel):

--- a/src/placefinder.py
+++ b/src/placefinder.py
@@ -1,7 +1,32 @@
+import importlib
+import sys
 from pathlib import Path
 from typing import Any
 
-import stargazingplacefinder as spf
+# ---------------------------------------------------------------------------
+# Defensive guard: ensure stargazingplacefinder's 'models' package is not
+# shadowed by mcp-stargazing's own src/models/ directory when src/ is on
+# sys.path (e.g. during development with `python -m src.main`).
+# ---------------------------------------------------------------------------
+_site_models = None
+try:
+    _site_models = importlib.util.find_spec('models')
+except (ImportError, ValueError, ModuleNotFoundError):
+    pass
+
+if _site_models is not None and _site_models.origin is not None:
+    _origin = _site_models.origin
+    _is_mcp_models = (
+        'mcp-stargazing' in _origin or 'mcp_stargazing' in _origin
+    ) and 'site-packages' not in _origin
+    if _is_mcp_models:
+        # 'models' resolves to mcp-stargazing's own models — this will break
+        # stargazingplacefinder below.  Restore site-packages priority.
+        _site_pkgs = [p for p in sys.path if 'site-packages' in p]
+        _rest = [p for p in sys.path if 'site-packages' not in p]
+        sys.path = _site_pkgs + _rest
+
+import stargazingplacefinder as spf  # noqa: E402
 
 
 class StargazingPlaceFinder:
@@ -34,14 +59,21 @@ class StargazingPlaceFinder:
         max_locations: int = 30,
         network_type: str = 'drive',
     ) -> list[dict[str, Any]]:
-        self.min_height_difference = min_height_diff
-        self.road_search_radius_km = road_radius_km
-        self.stargazing_analyzer = spf.init_stargazing_analyzer(
-            geotiff_path=self.geotiff_path,
-            min_height_difference=self.min_height_difference,
-            road_search_radius_km=self.road_search_radius_km,
-            db_config_path=self.db_config_path,
-        )
+        # Only re-init the analyzer when spatial parameters actually change.
+        # This avoids re-opening GeoTIFF files and re-creating PostGIS
+        # connection pools on every call (e.g. pagination).
+        if (
+            min_height_diff != self.min_height_difference
+            or road_radius_km != self.road_search_radius_km
+        ):
+            self.min_height_difference = min_height_diff
+            self.road_search_radius_km = road_radius_km
+            self.stargazing_analyzer = spf.init_stargazing_analyzer(
+                geotiff_path=self.geotiff_path,
+                min_height_difference=self.min_height_difference,
+                road_search_radius_km=self.road_search_radius_km,
+                db_config_path=self.db_config_path,
+            )
         return self.stargazing_analyzer.analyze_area(
             bbox=(south, west, north, east),
             max_locations=max_locations,

--- a/tests/test_structured_errors.py
+++ b/tests/test_structured_errors.py
@@ -97,19 +97,20 @@ def test_missing_api_key_error():
 
 @patch('src.functions.weather.impl.get_aggregated_weather_by_name')
 def test_weather_api_error_handling(mock_service):
-    """Test that weather API errors are properly handled with MCPError."""
+    """Test that weather API errors return structured error responses."""
     mock_service.side_effect = MCPError(
         MCPError.EXTERNAL_API_ERROR,
         'provider failed',
         {'place_name': 'Test City'},
     )
 
-    with pytest.raises(MCPError) as exc_info:
-        get_weather_by_name.fn('Test City')
+    result = get_weather_by_name.fn('Test City')
 
-    error = exc_info.value
-    assert error.code == MCPError.EXTERNAL_API_ERROR
-    assert error.details['place_name'] == 'Test City'
+    assert 'error' in result
+    assert '_meta' in result
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.EXTERNAL_API_ERROR
+    assert result['error']['details']['place_name'] == 'Test City'
 
 
 @patch('src.retry.time.sleep')  # Mock sleep to speed up test

--- a/uv.lock
+++ b/uv.lock
@@ -1819,7 +1819,7 @@ requires-dist = [
     { name = "pytz" },
     { name = "rasterio" },
     { name = "requests" },
-    { name = "stargazing-place-finder", specifier = ">=0.6.0,<1" },
+    { name = "stargazing-place-finder", specifier = ">=0.6.3,<1" },
     { name = "tzlocal" },
 ]
 
@@ -3305,7 +3305,7 @@ wheels = [
 
 [[package]]
 name = "stargazing-place-finder"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "flask" },
@@ -3324,9 +3324,9 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
 ]
-sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/c8/d5/b6f793fa5f9ee27dcafd04f12eb2a645dceef33253799ddcf01fea232424/stargazing_place_finder-0.6.2.tar.gz", hash = "sha256:18d1bcdd69e56c961beacf167874cfc8adf2de7d6ac3eaef4ca77a764604f994", size = 73310935 }
+sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/96/10/3e5bddff084f6fc56707571c44eba17055a42d58f8e730a6cbfd1cb37464/stargazing_place_finder-0.6.3.tar.gz", hash = "sha256:2848debf805487d9d7ce65d7ec46e6ae0a53d1d08953a955b264c8af0adb5c28", size = 73307184 }
 wheels = [
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/96/6c/4d955a457d84c5cc58905c9590bd80b22ba2f2aa100345bbf26e05a7ae7b/stargazing_place_finder-0.6.2-py3-none-any.whl", hash = "sha256:8d32b406d388e42aa0ff816c04b73f9ac4e4a0d4e7dc30be877d34fcfbf5e5f4", size = 73332506 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/36/e9/95746112ca2c089fa34b8be4d5199823d3a37828b2cfa85a19ee854175f2/stargazing_place_finder-0.6.3-py3-none-any.whl", hash = "sha256:143402d79ac23cb4f5f49199a5067f1b8ac76c04c67e576ef7f86a4dd8ab2a72", size = 73325666 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

修复 `light_pollution_map` 不可用、`analysis_area` PostGIS 调用失败、及天气工具异常处理问题。

## Root Causes

### light_pollution_map 不可用（3 个 bug 叠加）
1. **Key 名错误**：`impl.py` 读取 `raw.get('grid', [])`，但 spf 返回的是 `raw['data']` → grid 永远为空
2. **字段不匹配**：spf 用 `lng`，模型用 `lon`；spf 的 `sqm` 是字符串，模型期望 `float` → pydantic 校验崩溃
3. **包名冲突**：`src/` 在 sys.path 时 `mcp-stargazing/src/models/` 遮蔽 spf 的 `models` → ImportError

### analysis_area PostGIS 调用失败
- spf 的 `StargazingLocation` 对象未转换为 mcp 模型，字段名完全不匹配（如 `latitude` vs `lat`、`stargazing_score` vs `score`）
- `StargazingPlaceFinder.analyze_area()` 每次调用都重新创建分析器（重复打开 GeoTIFF / 建连接池）

### 天气工具
- 已有 open-meteo 免费 provider，但错误直接抛 MCPError 异常 → 改为返回结构化 error 响应

## Changes

| 文件 | 修改 |
|------|------|
| `src/functions/places/impl.py` | fix key `grid` → `data`，用 `from_spf_` 工厂转换模型 |
| `src/models/places.py` | 添加 `from_spf_point` / `from_spf_location` 工厂方法 |
| `src/placefinder.py` | 移除重复 init，按需重建；添加 `sys.path` 防御守卫 |
| `src/functions/weather/impl.py` | `raise MCPError` → `return format_error(...)` |
| `tests/test_structured_errors.py` | 更新测试匹配新行为 |
| `pyproject.toml` | `stargazing-place-finder >= 0.6.3` (等待 PyPI release) |

## Verification

- 67 tests pass (ruff + bandit + pytest) ✅
- MCP server `tools/list` 包含全部 12 个工具 ✅
- `light_pollution_map` 返回有效 grid 数据 ✅
- `analysis_area` 返回有效的 locations ✅
- `get_weather_by_position` 用 open-meteo 无需 API key ✅

## Depends on

- https://github.com/StarGazer1995/stargazing-place-finder/pull/49 (已合并，v0.6.3 tag 已推送，等待 PyPI release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)