### PR TITLE
chore(release): bump version to v0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-stargazing"
-version = "0.3.2"
+version = "0.3.3"
 description = "An MCP server that provides real-time astronomical data, smart stargazing planning, and light pollution analysis for AI agents."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1839,7 +1839,7 @@ wheels = [
 
 [[package]]
 name = "mcp-stargazing"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "astropy", extra = ["all"] },


### PR DESCRIPTION
## Summary
- bump package version from 0.3.2 to 0.3.3
- sync uv.lock root package version with the release bump

## Verification
- verified pyproject version reads as 0.3.3
- confirmed working tree is clean before PR creation