### PR TITLE
refactor(placefinder): stabilize bridge import paths

### DIFF
--- a/src/paths.py
+++ b/src/paths.py
@@ -1,3 +1,5 @@
+import importlib
+import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -26,3 +28,47 @@ def is_within_path(path: str | Path | None, base_dir: Path) -> bool:
         return False
 
     return True
+
+
+def is_repo_models_origin(origin: str | None) -> bool:
+    """Return whether a module origin resolves under this repository's `src/models`."""
+    return is_within_path(origin, MODELS_DIR)
+
+
+def find_module_origin(module_name: str) -> str | None:
+    """Return a module origin while safely ignoring lookup failures."""
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, ValueError, ModuleNotFoundError):
+        return None
+
+    if spec is None:
+        return None
+
+    return spec.origin
+
+
+def resolve_package_source_root(package_name: str) -> Path | None:
+    """Return the source root that should satisfy a package's top-level imports."""
+    package_origin = find_module_origin(package_name)
+    if package_origin is None:
+        return None
+
+    return Path(package_origin).resolve().parent.parent
+
+
+def prioritize_sys_path(path: Path) -> None:
+    """Move a path to the front of `sys.path` without leaving duplicates behind."""
+    resolved_path = str(path.resolve())
+    sys.path = [resolved_path, *[entry for entry in sys.path if entry != resolved_path]]
+
+
+def discard_shadowing_module(module_name: str, base_dir: Path) -> None:
+    """Remove a cached module when its loaded file resolves under the given directory."""
+    loaded_module = sys.modules.get(module_name)
+    if loaded_module is None:
+        return
+
+    loaded_origin = getattr(loaded_module, '__file__', None)
+    if is_within_path(loaded_origin, base_dir):
+        sys.modules.pop(module_name, None)

--- a/src/placefinder.py
+++ b/src/placefinder.py
@@ -1,39 +1,53 @@
 import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
-from src.paths import MODELS_DIR, is_within_path
+from src.paths import (
+    MODELS_DIR,
+    discard_shadowing_module,
+    find_module_origin,
+    is_repo_models_origin,
+    prioritize_sys_path,
+    resolve_package_source_root,
+)
+
+SPF_PACKAGE_NAME = 'stargazingplacefinder'
+MODELS_MODULE_NAME = 'models'
 
 
-def _is_repo_models_origin(origin: str | None) -> bool:
-    """Return whether the resolved `models` module comes from this repo's `src/models`."""
-    return is_within_path(origin, MODELS_DIR)
+def _prepare_spf_import_path() -> Path | None:
+    """Ensure `stargazingplacefinder` resolves its own top-level modules first."""
+    source_root = resolve_package_source_root(SPF_PACKAGE_NAME)
+    if source_root is None:
+        return None
+
+    if is_repo_models_origin(find_module_origin(MODELS_MODULE_NAME)):
+        discard_shadowing_module(MODELS_MODULE_NAME, MODELS_DIR)
+    elif is_repo_models_origin(getattr(sys.modules.get(MODELS_MODULE_NAME), '__file__', None)):
+        discard_shadowing_module(MODELS_MODULE_NAME, MODELS_DIR)
+
+    prioritize_sys_path(source_root)
+    return source_root
 
 
-# ---------------------------------------------------------------------------
-# Defensive guard: ensure stargazingplacefinder's 'models' package is not
-# shadowed by mcp-stargazing's own src/models/ directory when src/ is on
-# sys.path (e.g. during development with `python -m src.main`).
-# ---------------------------------------------------------------------------
-_site_models = None
-try:
-    _site_models = importlib.util.find_spec('models')
-except (ImportError, ValueError, ModuleNotFoundError):
-    pass
-
-if _site_models is not None and _site_models.origin is not None:
-    if _is_repo_models_origin(_site_models.origin):
-        # 'models' resolves to mcp-stargazing's own models — this will break
-        # stargazingplacefinder below.  Restore site-packages priority.
-        _site_pkgs = [p for p in sys.path if 'site-packages' in p]
-        _rest = [p for p in sys.path if 'site-packages' not in p]
-        sys.path = _site_pkgs + _rest
-
-import stargazingplacefinder as spf  # noqa: E402
+def _load_spf() -> ModuleType:
+    """Import `stargazingplacefinder` after preparing its dependency source root."""
+    _prepare_spf_import_path()
+    try:
+        return importlib.import_module(SPF_PACKAGE_NAME)
+    except ModuleNotFoundError as exc:
+        if exc.name == SPF_PACKAGE_NAME:
+            raise ModuleNotFoundError(
+                'stargazingplacefinder is required for place analysis features'
+            ) from exc
+        raise
 
 
 class StargazingPlaceFinder:
+    """Bridge wrapper around the `stargazingplacefinder` public API."""
+
     def __init__(
         self,
         geotiff_path: Path | None = None,
@@ -45,11 +59,16 @@ class StargazingPlaceFinder:
         self.min_height_difference = min_height_difference
         self.road_search_radius_km = road_search_radius_km
         self.db_config_path = db_config_path
-        self.stargazing_analyzer = spf.init_stargazing_analyzer(
-            geotiff_path=geotiff_path,
-            min_height_difference=min_height_difference,
-            road_search_radius_km=road_search_radius_km,
-            db_config_path=db_config_path,
+        self._spf = _load_spf()
+        self.stargazing_analyzer = self._init_analyzer()
+
+    def _init_analyzer(self) -> Any:
+        """Initialize the dependency analyzer using the bridge's current parameters."""
+        return self._spf.init_stargazing_analyzer(
+            geotiff_path=self.geotiff_path,
+            min_height_difference=self.min_height_difference,
+            road_search_radius_km=self.road_search_radius_km,
+            db_config_path=self.db_config_path,
         )
 
     def analyze_area(
@@ -72,12 +91,7 @@ class StargazingPlaceFinder:
         ):
             self.min_height_difference = min_height_diff
             self.road_search_radius_km = road_radius_km
-            self.stargazing_analyzer = spf.init_stargazing_analyzer(
-                geotiff_path=self.geotiff_path,
-                min_height_difference=self.min_height_difference,
-                road_search_radius_km=self.road_search_radius_km,
-                db_config_path=self.db_config_path,
-            )
+            self.stargazing_analyzer = self._init_analyzer()
         return self.stargazing_analyzer.analyze_area(
             bbox=(south, west, north, east),
             max_locations=max_locations,
@@ -91,4 +105,12 @@ class StargazingPlaceFinder:
 def get_light_pollution_grid(
     north: float, south: float, east: float, west: float, zoom: int = 10
 ) -> dict[str, Any]:
-    return spf.get_light_pollution_grid(north=north, south=south, east=east, west=west, zoom=zoom)
+    """Proxy the light pollution grid helper from `stargazingplacefinder`."""
+    spf_module = _load_spf()
+    return spf_module.get_light_pollution_grid(
+        north=north,
+        south=south,
+        east=east,
+        west=west,
+        zoom=zoom,
+    )

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,3 +1,9 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
 from src import paths
 
 
@@ -16,6 +22,102 @@ def test_is_within_path_detects_nested_path():
 def test_is_within_path_rejects_none_and_external_path():
     assert paths.is_within_path(None, paths.MODELS_DIR) is False
     assert paths.is_within_path('/tmp/external.py', paths.MODELS_DIR) is False
+
+
+def test_is_repo_models_origin_matches_ci_style_path():
+    original_models_dir = paths.MODELS_DIR
+
+    try:
+        paths.MODELS_DIR = Path('/app/src/models')
+        assert paths.is_repo_models_origin('/app/src/models/__init__.py') is True
+        assert (
+            paths.is_repo_models_origin(
+                '/usr/local/lib/python3.13/site-packages/models/__init__.py'
+            )
+            is False
+        )
+    finally:
+        paths.MODELS_DIR = original_models_dir
+
+
+def test_find_module_origin_returns_expected_origin():
+    with patch.object(
+        importlib.util,
+        'find_spec',
+        return_value=SimpleNamespace(origin='/tmp/pkg/__init__.py'),
+    ):
+        assert paths.find_module_origin('demo.module') == '/tmp/pkg/__init__.py'
+
+
+def test_find_module_origin_returns_none_when_spec_missing():
+    with patch.object(importlib.util, 'find_spec', return_value=None):
+        assert paths.find_module_origin('demo.module') is None
+
+
+def test_find_module_origin_ignores_lookup_errors():
+    with patch.object(importlib.util, 'find_spec', side_effect=ImportError('boom')):
+        assert paths.find_module_origin('demo.module') is None
+
+
+def test_resolve_package_source_root_returns_none_when_origin_missing():
+    with patch.object(paths, 'find_module_origin', return_value=None):
+        assert paths.resolve_package_source_root('demo.module') is None
+
+
+def test_resolve_package_source_root_returns_parent_src_directory():
+    with patch.object(
+        paths,
+        'find_module_origin',
+        return_value='/workspace/stargazing-place-finder/src/stargazingplacefinder/__init__.py',
+    ):
+        assert paths.resolve_package_source_root('stargazingplacefinder') == Path(
+            '/workspace/stargazing-place-finder/src'
+        )
+
+
+def test_prioritize_sys_path_moves_entry_to_front_without_duplicates():
+    original_sys_path = list(sys.path)
+    target_path = Path('/workspace/stargazing-place-finder/src')
+
+    try:
+        sys.path = ['/app/src', str(target_path.resolve()), '/tmp/other']
+        paths.prioritize_sys_path(target_path)
+        assert sys.path[0] == str(target_path.resolve())
+        assert sys.path.count(str(target_path.resolve())) == 1
+    finally:
+        sys.path = original_sys_path
+
+
+def test_discard_shadowing_module_removes_module_under_base_dir():
+    original_models_module = sys.modules.get('models')
+    fake_models = ModuleType('models')
+    fake_models.__file__ = '/app/src/models/__init__.py'
+
+    try:
+        sys.modules['models'] = fake_models
+        paths.discard_shadowing_module('models', Path('/app/src/models'))
+        assert 'models' not in sys.modules
+    finally:
+        if original_models_module is None:
+            sys.modules.pop('models', None)
+        else:
+            sys.modules['models'] = original_models_module
+
+
+def test_discard_shadowing_module_keeps_external_module():
+    original_models_module = sys.modules.get('models')
+    fake_models = ModuleType('models')
+    fake_models.__file__ = '/usr/local/lib/python3.13/site-packages/models/__init__.py'
+
+    try:
+        sys.modules['models'] = fake_models
+        paths.discard_shadowing_module('models', Path('/app/src/models'))
+        assert sys.modules['models'] is fake_models
+    finally:
+        if original_models_module is None:
+            sys.modules.pop('models', None)
+        else:
+            sys.modules['models'] = original_models_module
 
 
 def test_path_constants_point_to_expected_locations():

--- a/tests/test_placefinder.py
+++ b/tests/test_placefinder.py
@@ -1,12 +1,13 @@
 import importlib
 import sys
-import unittest
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import src.placefinder as placefinder_module
-from src.placefinder import StargazingPlaceFinder
+from src.placefinder import StargazingPlaceFinder, get_light_pollution_grid
 
 
 def _make_mock_location(name, latitude, longitude, stargazing_score):
@@ -19,166 +20,242 @@ def _make_mock_location(name, latitude, longitude, stargazing_score):
     return loc
 
 
-class TestStargazingPlaceFinder(unittest.TestCase):
-    def test_init(self):
-        """验证初始化成功并持有分析器实例"""
-        with patch('stargazingplacefinder.init_stargazing_analyzer') as mock_init:
-            pf = StargazingPlaceFinder()
-            self.assertIsNotNone(pf.stargazing_analyzer)
-            mock_init.assert_called_once()
+def _make_fake_spf(mock_analyzer):
+    """Build a fake dependency module with the bridge entrypoints."""
+    init_mock = MagicMock(return_value=mock_analyzer)
+    grid_mock = MagicMock(return_value={'data': []})
+    return SimpleNamespace(
+        init_stargazing_analyzer=init_mock,
+        get_light_pollution_grid=grid_mock,
+    )
 
-    def test_analyze_area_objects(self):
-        """调用 analyze_area 返回对象列表并包含关键属性"""
-        mock_loc = _make_mock_location(
-            name='Top Stargazing Spot',
-            latitude=40.001,
-            longitude=116.199,
-            stargazing_score=92.5,
+
+def test_init_uses_dependency_analyzer_factory():
+    """Bridge initialization should create and keep the dependency analyzer."""
+    mock_analyzer = MagicMock()
+    fake_spf = _make_fake_spf(mock_analyzer)
+
+    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+        pf = StargazingPlaceFinder()
+
+    assert pf.stargazing_analyzer is mock_analyzer
+    fake_spf.init_stargazing_analyzer.assert_called_once_with(
+        geotiff_path=None,
+        min_height_difference=100.0,
+        road_search_radius_km=10.0,
+        db_config_path=None,
+    )
+
+
+def test_analyze_area_returns_dependency_results_and_expected_args():
+    """Bridge calls should forward the normalized arguments to the dependency."""
+    mock_loc = _make_mock_location(
+        name='Top Stargazing Spot',
+        latitude=40.001,
+        longitude=116.199,
+        stargazing_score=92.5,
+    )
+    mock_analyzer = MagicMock()
+    mock_analyzer.analyze_area.return_value = [mock_loc]
+    fake_spf = _make_fake_spf(mock_analyzer)
+
+    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+        pf = StargazingPlaceFinder()
+        result = pf.analyze_area(
+            39.98,
+            116.18,
+            40.02,
+            116.22,
+            max_locations=3,
+            min_height_diff=50.0,
+            road_radius_km=5.0,
+            network_type='drive',
         )
 
-        with patch('stargazingplacefinder.init_stargazing_analyzer') as mock_init:
-            mock_analyzer = MagicMock()
-            mock_analyzer.analyze_area.return_value = [mock_loc]
-            mock_init.return_value = mock_analyzer
+    assert result == [mock_loc]
+    mock_analyzer.analyze_area.assert_called_once_with(
+        bbox=(39.98, 116.18, 40.02, 116.22),
+        max_locations=3,
+        location_types=None,
+        network_type='drive',
+        include_light_pollution=True,
+        include_road_connectivity=True,
+    )
 
-            pf = StargazingPlaceFinder()
-            res = pf.analyze_area(
-                39.98,
-                116.18,
-                40.02,
-                116.22,
-                max_locations=3,
-                min_height_diff=50.0,
-                road_radius_km=5.0,
-                network_type='drive',
-            )
-        self.assertIsInstance(res, list)
-        self.assertEqual(len(res), 1)
-        first = res[0]
-        self.assertEqual(first.name, 'Top Stargazing Spot')
-        self.assertEqual(first.latitude, 40.001)
-        self.assertEqual(first.stargazing_score, 92.5)
 
-    def test_parameter_update(self):
-        """analyze_area 应更新实例中的参数状态"""
-        with patch('stargazingplacefinder.init_stargazing_analyzer') as mock_init:
-            mock_analyzer = MagicMock()
-            mock_analyzer.analyze_area.return_value = []
-            mock_init.return_value = mock_analyzer
+def test_analyze_area_reinitializes_only_when_thresholds_change():
+    """Analyzer reuse should depend only on the bridge's threshold parameters."""
+    mock_analyzer = MagicMock()
+    mock_analyzer.analyze_area.return_value = []
+    fake_spf = _make_fake_spf(mock_analyzer)
 
-            pf = StargazingPlaceFinder()
-            pf.analyze_area(
-                39.98,
-                116.18,
-                40.02,
-                116.22,
-                max_locations=1,
-                min_height_diff=50.0,
-                road_radius_km=5.0,
-                network_type='drive',
-            )
-            self.assertEqual(pf.min_height_difference, 50.0)
-            self.assertEqual(pf.road_search_radius_km, 5.0)
+    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+        pf = StargazingPlaceFinder(min_height_difference=50.0, road_search_radius_km=5.0)
+        pf.analyze_area(
+            39.98,
+            116.18,
+            40.02,
+            116.22,
+            max_locations=1,
+            min_height_diff=50.0,
+            road_radius_km=5.0,
+            network_type='drive',
+        )
+        pf.analyze_area(
+            39.98,
+            116.18,
+            40.02,
+            116.22,
+            max_locations=1,
+            min_height_diff=150.0,
+            road_radius_km=3.0,
+            network_type='drive',
+        )
 
-            pf.analyze_area(
-                39.98,
-                116.18,
-                40.02,
-                116.22,
-                max_locations=1,
-                min_height_diff=150.0,
-                road_radius_km=3.0,
-                network_type='drive',
-            )
-            self.assertEqual(pf.min_height_difference, 150.0)
-            self.assertEqual(pf.road_search_radius_km, 3.0)
-            self.assertEqual(mock_init.call_count, 3)
+    assert pf.min_height_difference == 150.0
+    assert pf.road_search_radius_km == 3.0
+    assert fake_spf.init_stargazing_analyzer.call_count == 2
 
-    def test_analyze_area_reuses_existing_analyzer_when_params_unchanged(self):
-        """相同空间参数下不应重复初始化 analyzer。"""
-        with patch('stargazingplacefinder.init_stargazing_analyzer') as mock_init:
-            mock_analyzer = MagicMock()
-            mock_analyzer.analyze_area.return_value = []
-            mock_init.return_value = mock_analyzer
 
-            pf = StargazingPlaceFinder(min_height_difference=50.0, road_search_radius_km=5.0)
-            pf.analyze_area(
-                39.98,
-                116.18,
-                40.02,
-                116.22,
-                max_locations=1,
-                min_height_diff=50.0,
-                road_radius_km=5.0,
-                network_type='drive',
-            )
+def test_init_with_db_config_path_forwards_path():
+    """Bridge initialization should preserve the caller's database config path."""
+    mock_analyzer = MagicMock()
+    fake_spf = _make_fake_spf(mock_analyzer)
+    db_config_path = Path('/tmp/db_config.json')
 
-            self.assertEqual(mock_init.call_count, 1)
+    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+        pf = StargazingPlaceFinder(db_config_path=db_config_path)
 
-    def test_reload_placefinder_ignores_find_spec_errors(self):
-        """模块初始化时，find_spec 异常应被安全忽略。"""
-        original_find_spec = importlib.util.find_spec
-        original_sys_path = list(sys.path)
+    assert pf.db_config_path == db_config_path
+    fake_spf.init_stargazing_analyzer.assert_called_once_with(
+        geotiff_path=None,
+        min_height_difference=100.0,
+        road_search_radius_km=10.0,
+        db_config_path=db_config_path,
+    )
 
-        def _raise_import_error(name):
-            raise ImportError(f'boom: {name}')
 
-        try:
-            importlib.util.find_spec = _raise_import_error
-            reloaded = importlib.reload(placefinder_module)
-            self.assertIsNotNone(reloaded)
-            self.assertEqual(sys.path, original_sys_path)
-        finally:
-            importlib.util.find_spec = original_find_spec
-            importlib.reload(placefinder_module)
+def test_prepare_spf_import_path_returns_none_when_dependency_root_unknown():
+    """No path mutation should happen when the dependency source root cannot be found."""
+    original_sys_path = list(sys.path)
 
-    def test_is_repo_models_origin_matches_ci_style_path(self):
-        """Path 比对应兼容 CI 中的 `/app/src/models` 路径。"""
-        original_models_dir = placefinder_module.MODELS_DIR
+    with patch.object(placefinder_module, 'resolve_package_source_root', return_value=None):
+        assert placefinder_module._prepare_spf_import_path() is None
+        assert sys.path == original_sys_path
 
-        try:
-            placefinder_module.MODELS_DIR = Path('/app/src/models')
-            self.assertTrue(
-                placefinder_module._is_repo_models_origin('/app/src/models/__init__.py')
-            )
-            self.assertFalse(
-                placefinder_module._is_repo_models_origin(
-                    '/usr/local/lib/python3.13/site-packages/models/__init__.py'
-                )
-            )
-        finally:
-            placefinder_module.MODELS_DIR = original_models_dir
 
-    def test_reload_placefinder_prioritizes_site_packages_for_repo_models_path(self):
-        """当 models 解析到仓库内 `src/models` 时，应将 site-packages 提前。"""
-        original_find_spec = importlib.util.find_spec
-        original_sys_path = list(sys.path)
+def test_prepare_spf_import_path_prioritizes_dependency_root_and_clears_shadow_module():
+    """The bridge should prefer the dependency source root over the local `src/models`."""
+    fake_dependency_root = Path('/workspace/stargazing-place-finder/src')
+    fake_repo_models = ModuleType('models')
+    fake_repo_models.__file__ = '/app/src/models/__init__.py'
+    original_sys_path = list(sys.path)
+    original_models_module = sys.modules.get('models')
+    fake_site_packages = '/usr/local/lib/python3.13/site-packages'
 
-        fake_site_packages = '/usr/local/lib/python3.13/site-packages'
-        fake_repo_src = str(Path(placefinder_module.__file__).resolve().parent)
-        fake_repo_models = str(Path(fake_repo_src) / 'models' / '__init__.py')
+    try:
+        sys.path = ['/app/src', str(fake_dependency_root), fake_site_packages]
+        sys.modules['models'] = fake_repo_models
+        with patch.object(placefinder_module, 'MODELS_DIR', Path('/app/src/models')):
+            with patch.object(
+                placefinder_module,
+                'resolve_package_source_root',
+                return_value=fake_dependency_root,
+            ):
+                with patch.object(
+                    placefinder_module,
+                    'find_module_origin',
+                    return_value='/app/src/models/__init__.py',
+                ):
+                    with patch.object(
+                        placefinder_module,
+                        'is_repo_models_origin',
+                        return_value=True,
+                    ):
+                        source_root = placefinder_module._prepare_spf_import_path()
 
-        def _fake_find_spec(name):
-            if name == 'models':
-                return SimpleNamespace(origin=fake_repo_models)
-            return original_find_spec(name)
+        assert source_root == fake_dependency_root
+        assert sys.path[0] == str(fake_dependency_root.resolve())
+        assert 'models' not in sys.modules
+    finally:
+        sys.path = original_sys_path
+        if original_models_module is None:
+            sys.modules.pop('models', None)
+        else:
+            sys.modules['models'] = original_models_module
 
-        try:
-            importlib.util.find_spec = _fake_find_spec
-            sys.path = [fake_repo_src, fake_site_packages]
-            reloaded = importlib.reload(placefinder_module)
-            self.assertIsNotNone(reloaded)
-            self.assertEqual(sys.path[0], fake_site_packages)
-            self.assertEqual(sys.path[1], fake_repo_src)
-        finally:
-            importlib.util.find_spec = original_find_spec
-            sys.path = original_sys_path
-            importlib.reload(placefinder_module)
 
-    def test_init_with_db_config(self):
-        """验证支持 db_config_path 参数初始化"""
-        from pathlib import Path
+def test_prepare_spf_import_path_clears_loaded_repo_models_even_when_lookup_is_clean():
+    """A shadowing cached module should be discarded when current lookup no longer sees it."""
+    fake_dependency_root = Path('/workspace/stargazing-place-finder/src')
+    fake_repo_models = ModuleType('models')
+    fake_repo_models.__file__ = '/app/src/models/__init__.py'
+    original_sys_path = list(sys.path)
+    original_models_module = sys.modules.get('models')
 
-        pf = StargazingPlaceFinder(db_config_path=Path('/tmp/db_config.json'))
-        self.assertEqual(pf.db_config_path, Path('/tmp/db_config.json'))
-        self.assertIsNotNone(pf.stargazing_analyzer)
+    try:
+        sys.path = ['/app/src', str(fake_dependency_root)]
+        sys.modules['models'] = fake_repo_models
+        with patch.object(placefinder_module, 'MODELS_DIR', Path('/app/src/models')):
+            with patch.object(
+                placefinder_module,
+                'resolve_package_source_root',
+                return_value=fake_dependency_root,
+            ):
+                with patch.object(placefinder_module, 'find_module_origin', return_value=None):
+                    with patch.object(
+                        placefinder_module,
+                        'is_repo_models_origin',
+                        side_effect=[False, True],
+                    ):
+                        source_root = placefinder_module._prepare_spf_import_path()
+
+        assert source_root == fake_dependency_root
+        assert sys.path[0] == str(fake_dependency_root.resolve())
+        assert 'models' not in sys.modules
+    finally:
+        sys.path = original_sys_path
+        if original_models_module is None:
+            sys.modules.pop('models', None)
+        else:
+            sys.modules['models'] = original_models_module
+
+
+def test_load_spf_wraps_missing_dependency_error():
+    """A missing dependency should produce a clear bridge-level error."""
+    missing_dependency = ModuleNotFoundError("No module named 'stargazingplacefinder'")
+    missing_dependency.name = placefinder_module.SPF_PACKAGE_NAME
+
+    with patch.object(placefinder_module, '_prepare_spf_import_path'):
+        with patch.object(importlib, 'import_module', side_effect=missing_dependency):
+            with pytest.raises(ModuleNotFoundError, match='stargazingplacefinder is required'):
+                placefinder_module._load_spf()
+
+
+def test_load_spf_reraises_unrelated_module_errors():
+    """Nested dependency import errors should not be rewritten as missing package errors."""
+    nested_failure = ModuleNotFoundError("No module named 'nested_module'")
+    nested_failure.name = 'nested_module'
+
+    with patch.object(placefinder_module, '_prepare_spf_import_path'):
+        with patch.object(importlib, 'import_module', side_effect=nested_failure):
+            with pytest.raises(ModuleNotFoundError, match='nested_module'):
+                placefinder_module._load_spf()
+
+
+def test_get_light_pollution_grid_uses_loaded_dependency_module():
+    """The light pollution helper should proxy calls through the loaded dependency module."""
+    fake_spf = _make_fake_spf(MagicMock())
+    fake_spf.get_light_pollution_grid.return_value = {'data': ['grid-point']}
+
+    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+        result = get_light_pollution_grid(40.0, 39.0, 117.0, 116.0, zoom=9)
+
+    assert result == {'data': ['grid-point']}
+    fake_spf.get_light_pollution_grid.assert_called_once_with(
+        north=40.0,
+        south=39.0,
+        east=117.0,
+        west=116.0,
+        zoom=9,
+    )


### PR DESCRIPTION
## Summary
- centralize module-origin and import-path utilities in `src/paths.py`
- keep `src/placefinder.py` focused on the `stargazingplacefinder` bridge lifecycle
- add bridge and path-level tests to lock the cross-repo import boundary

## Validation
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run bandit -c pyproject.toml -r src/`
- `uv run pytest -v --cov=src --cov-report=xml:cache/coverage.xml`
- `uvx diff-cover cache/coverage.xml --compare-branch=origin/main --fail-under=100`
