### PR TITLE
refactor(protocol): unify tool contract handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,10 @@ This is not a runtime requirement, but it is the best place for team-level regul
 - All MCP tools must be defined under `src/functions/`.
 - Each tool module must import `src.server_instance.mcp` and decorate tool entrypoints with `@mcp.tool()`.
 - The repository should keep tool registration centralized in `src/main.py` by importing tool modules there.
+- When explicit `@mcp.tool(name=..., description=...)` metadata is provided, that metadata takes precedence over the function name and docstring and should be treated as the public contract.
 - Example domains:
   - `src/functions/celestial/impl.py`
+  - `src/functions/metadata/impl.py`
   - `src/functions/weather/impl.py`
   - `src/functions/places/impl.py`
   - `src/functions/time/impl.py`
@@ -35,6 +37,7 @@ This is not a runtime requirement, but it is the best place for team-level regul
 
 - All tools must return JSON-serializable data.
 - Use `src.response.format_response(...)` for standard response wrapping.
+- Business validation failures that remain inside normal tool execution should return the structured `{error, _meta}` payload shape instead of ad hoc dicts.
 - Dates and times should be returned as ISO strings whenever possible.
 - Keep tool argument names clear and stable; renames should be treated as breaking changes.
 - Add new tools only after verifying the new interface is agent-friendly and documented.
@@ -54,6 +57,7 @@ This is not a runtime requirement, but it is the best place for team-level regul
   - `NETWORK_ERROR`: Network connectivity issues
   - `CONFIGURATION_ERROR`: Configuration problems
 - Avoid raising raw exceptions from tools; catch and translate them into structured MCPError responses.
+- Prefer translating input and validation failures at the boundary helper level so tool functions stay simple; avoid scattering repetitive `try/except` blocks across individual tool implementations.
 - Weather tools include automatic retry logic for network failures (up to 3 attempts with exponential backoff).
 - Tool failures should be explicit and actionable for the calling agent.
 
@@ -64,10 +68,14 @@ This is not a runtime requirement, but it is the best place for team-level regul
 - Existing harness patterns:
   - `tests/test_integration.py` validates tool registration via `mcp._tool_manager._tools`
   - `tests/test_serialization.py` validates the JSON response shape
+  - `tests/test_mcp_client.py` validates `tools/list`, `tools/call`, and SSE request-id behavior
+  - `tests/test_server_instance.py` validates metadata registry stability and catalog copy semantics
+  - `tests/test_structured_errors.py` validates business error payload normalization
 - When adding a new tool, add at least one test that:
   1. imports the tool module so it is registered
   2. verifies the tool exists on `mcp`
   3. verifies the tool returns correct JSON structure
+  4. verifies any new agent-facing metadata stays aligned with `tools/list` / catalog expectations when applicable
 
 ## Agent development workflow
 
@@ -82,6 +90,7 @@ This is not a runtime requirement, but it is the best place for team-level regul
     ```bash
     python -m src.main --mode shttp --port 3001 --path /shttp
     ```
+    Prefer `shttp`, `sse`, or `local`; `dev` mode is not a reliable local workflow on current FastMCP versions because `run_dev()` has been removed upstream.
 3.  Use examples for agent integration patterns:
     - `examples/shttp_tools_demo.py`
     - `examples/stream_http_analysis_area.py`
@@ -106,8 +115,7 @@ This is not a runtime requirement, but it is the best place for team-level regul
 ## Future roadmap
 
 See `docs/ROADMAP.md` for the planned agent and harness feature roadmap, including:
-- tool metadata and discovery, including a registered discovery tool (`get_tool_catalog`)
-- structured error handling
+- remaining contract hardening for metadata, errors, and transport behavior
 - composite planning tools
 - streamed large-search support
 - expanded astronomy domain features

--- a/README.md
+++ b/README.md
@@ -142,15 +142,15 @@ All tools return data in a standardized JSON format:
 - **`get_celestial_pos`**: Calculate altitude/azimuth.
 - **`get_celestial_rise_set`**: Calculate rise/set times (Returns ISO strings).
 - **`get_moon_info`**: Detailed moon phase, illumination, and age.
-- **`get_visible_planets`**: List of all planets currently above the horizon with positions.
+- **`list_visible_planets`**: List of all planets currently above the horizon with positions.
 - **`get_constellation`**: Find the position (Alt/Az) of a constellation center.
 - **`get_nightly_forecast`**: Smart planner returning curated list of best objects to view tonight (Planets + Deep Sky).
 - **`get_weather_by_name` / `get_weather_by_position`**: Fetch current weather with automatic retry on network failures.
 - **`get_local_datetime_info`**: Get current local time information.
 - **`get_tool_catalog`**: Discover available MCP tool metadata and parameters.
 - **`analysis_area`**: Find best stargazing spots in a region.
-  - **Inputs**: `top_left`, `bottom_right`, `time`, `page`, `page_size`.
-  - **Returns**: List of spots with viewing conditions, plus pagination metadata (`total`, `resource_id`).
+  - **Inputs**: `south`, `west`, `north`, `east`, `max_locations`, `min_height_diff`, `road_radius_km`, `network_type`, `db_config_path`, `page`, `page_size`.
+  - **Returns**: List of spots with pagination metadata (`total`, `page`, `page_size`, `total_pages`) and a `resource_id` that identifies the cached non-pagination query parameters.
 
 ### 5. Error Handling
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Calculate the altitude, rise, and set times of celestial objects (Sun, Moon, pla
 - **Altitude/Azimuth Calculation**: Get elevation and compass direction for any celestial object.
 - **Rise/Set Times**: Determine when objects appear/disappear above the horizon.
 - **Light Pollution Analysis**: Load and analyze light pollution maps (GeoTIFF format).
+- **Tool Discovery**: Inspect registered MCP tools programmatically through `get_tool_catalog`.
 - **Code Execution Ready**:
   - **Serializable Returns**: All tools return JSON-serializable data (ISO strings for dates), making them directly usable by LLMs.
   - **Pagination**: `analysis_area` supports paging (`page`, `page_size`) to handle large datasets efficiently.
-  - **Standardized Responses**: Uniform response format `{ "data": ..., "_meta": ... }` for better observability and error handling.
+  - **Stable Result Handles**: `analysis_area.resource_id` identifies the cached non-pagination query so agents can fetch multiple pages safely.
+  - **Standardized Responses**: Successful calls return `{ "data": ..., "_meta": ... }`; business validation failures return `{ "error": ..., "_meta": ... }`.
 - **Performance**:
   - **Async Execution**: Non-blocking celestial calculations.
   - **Caching**: Intelligent caching for Simbad queries and regional analysis.
@@ -119,9 +121,11 @@ python -m src.main --mode shttp --port 3001 --path /shttp --proxy http://127.0.0
 python -m src.main --mode sse --port 3001 --path /sse
 ```
 
+`dev` mode is still accepted by the CLI for backwards compatibility, but current FastMCP versions no longer provide `run_dev()`. Prefer `shttp`, `sse`, or `local`.
+
 ### 3. Response Format
 
-All tools return data in a standardized JSON format:
+Successful business responses return data in a standardized JSON format:
 
 ```json
 {
@@ -137,6 +141,26 @@ All tools return data in a standardized JSON format:
 }
 ```
 
+Business validation failures use the same envelope style:
+
+```json
+{
+  "error": {
+    "code": "INVALID_TIME_FORMAT",
+    "message": "Invalid time format: invalid-time-format",
+    "details": {
+      "time_string": "invalid-time-format"
+    }
+  },
+  "_meta": {
+    "version": "1.0.0",
+    "status": "error"
+  }
+}
+```
+
+At the MCP protocol layer, `tools/list` and `get_tool_catalog` are kept aligned, and JSON-RPC request ids are preserved in both SHTTP and SSE transport tests.
+
 ### 4. Available Tools
 
 - **`get_celestial_pos`**: Calculate altitude/azimuth.
@@ -151,6 +175,7 @@ All tools return data in a standardized JSON format:
 - **`analysis_area`**: Find best stargazing spots in a region.
   - **Inputs**: `south`, `west`, `north`, `east`, `max_locations`, `min_height_diff`, `road_radius_km`, `network_type`, `db_config_path`, `page`, `page_size`.
   - **Returns**: List of spots with pagination metadata (`total`, `page`, `page_size`, `total_pages`) and a `resource_id` that identifies the cached non-pagination query parameters.
+  - **Validation**: `page >= 1` and `page_size >= 1`; invalid pagination arguments return `CONFIGURATION_ERROR`.
 
 ### 5. Error Handling
 
@@ -158,7 +183,8 @@ All tools return JSON-serializable data and use structured error handling:
 
 - **Standard Error Codes**: `INVALID_COORDINATES`, `INVALID_TIMEZONE`, `INVALID_TIME_FORMAT`, `MISSING_API_KEY`, `API_AUTH_FAILURE`, `API_TIMEOUT`, `API_RATE_LIMIT`, `EXTERNAL_API_ERROR`, `NETWORK_ERROR`, `CONFIGURATION_ERROR`
 - **Weather Tools**: Include automatic retry logic for network failures (up to 3 attempts with exponential backoff)
-- **Error Responses**: Structured MCPError objects with actionable error messages for calling agents
+- **Business Error Responses**: Structured MCPError-derived payloads with actionable messages for calling agents
+- **Protocol Tests**: `tools/list`, `get_tool_catalog`, and SSE request-id behavior are covered by protocol-level tests
 - **Validation**: Input parameters are validated before processing with clear error messages
 
 ## Examples
@@ -188,6 +214,7 @@ The project is modularized for better maintainability and code execution support
 ├── src/
 │   ├── functions/            # Tool implementations grouped by domain
 │   │   ├── celestial/        # Celestial calculations (pos, rise/set)
+│   │   ├── metadata/         # Tool discovery surface (`get_tool_catalog`)
 │   │   ├── weather/          # Weather API integration
 │   │   ├── places/           # Location and area analysis
 │   │   └── time/             # Time utilities
@@ -197,11 +224,14 @@ The project is modularized for better maintainability and code execution support
 │   ├── main.py               # Entry point and tool registration
 │   ├── celestial.py          # Core astronomy logic (Astropy wrappers)
 │   ├── placefinder.py        # Grid analysis logic
-│   └── qweather_interaction.py # Weather API client
+│   └── qweather_interaction.py # Legacy QWeather helpers
 ├── tests/                    # Unified test suite
 │   ├── test_celestial.py
+│   ├── test_mcp_client.py    # MCP protocol and transport contract tests
+│   ├── test_server_instance.py # Tool metadata registry behavior
 │   ├── test_weather.py
 │   ├── test_serialization.py # Validates JSON return formats
+│   ├── test_structured_errors.py # Structured business error expectations
 │   └── test_integration.py   # End-to-end flow tests
 ├── examples/                 # Usage examples
 ├── docs/                     # Documentation and improvement plans
@@ -213,12 +243,14 @@ The project is modularized for better maintainability and code execution support
 Run the unified test suite:
 
 ```bash
-pytest tests/
+uv run pytest -v tests/
 ```
 
 Key tests include:
 - `test_serialization.py`: Ensures all tools return valid JSON with the correct schema.
 - `test_integration.py`: Mocks external APIs to verify the entire toolchain.
+- `test_mcp_client.py`: Verifies `tools/list`, `tools/call`, and SSE request-id protocol behavior.
+- `test_structured_errors.py`: Verifies business validation failures stay in the structured response envelope.
 
 ## Contributing
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,27 +1,32 @@
 # MCP Stargazing Roadmap
 
-This roadmap captures future agent-facing, harness, and feature improvements for `mcp-stargazing`.
+This roadmap tracks the remaining agent-facing, harness, and feature work for `mcp-stargazing`.
 
-## Priority 1: Agent discovery and robustness
+## Recently completed foundation work
 
-1.  Tool metadata and discovery
-    - Expose each tool's name, description, parameters, and return schema programmatically.
-    - Add a tool catalog endpoint or manifest so agents can discover capabilities automatically.
-    - Provide a registered discovery tool (`get_tool_catalog`) for agents to inspect available MCP capabilities.
-    - Standardize schema documentation in code and generated docs.
+The following baseline capabilities are already implemented and should no longer be treated as future work:
 
-2.  Structured errors and retry semantics
-    - Use `src.response.MCPError` consistently for agent-visible failures.
-    - Define structured error codes for common failure cases:
-      - invalid coordinates
-      - missing API key / auth failure
-      - external API timeout/failure
-    - Add retry/fallback behavior for weather and external catalog lookups.
+- Tool discovery is available through the registered `get_tool_catalog` tool.
+- Tool metadata is exposed programmatically and kept aligned with `tools/list`.
+- Business validation failures are normalized into the standard `{error, _meta}` payload shape.
+- Weather tools already include retry behavior for transient network failures.
+- `analysis_area` now has explicit pagination validation and stable `resource_id` semantics based only on non-pagination query parameters.
+- MCP protocol tests now verify `tools/list` / catalog consistency and SSE JSON-RPC request id preservation.
 
-3.  Agent-ready response format
-    - Ensure all tools return JSON-serializable data.
-    - Strengthen the response wrapper shape and normalize `_meta` content.
-    - Add tests for response consistency and schema validation.
+## Priority 1: Finish contract hardening
+
+1.  Schema and documentation consistency
+    - Keep tool descriptions, parameter docs, and return-shape documentation synchronized across code, `README.md`, and generated tool metadata.
+    - Add stronger field-level checks for tool metadata drift when new tools are introduced.
+
+2.  Error contract consistency
+    - Continue migrating agent-visible validation failures to `src.response.MCPError`.
+    - Reduce mixed error paths where some failures return business payloads while others surface as transport-level JSON-RPC errors.
+    - Keep error codes stable and documented for calling agents.
+
+3.  Transport and protocol robustness
+    - Extend protocol-level tests beyond the current SHTTP/SSE request-id and `tools/list` coverage.
+    - Add focused coverage for any future transport-specific behavior changes.
 
 ## Priority 2: Composite planning tools
 
@@ -42,7 +47,7 @@ This roadmap captures future agent-facing, harness, and feature improvements for
 1.  Better `analysis_area`
     - Add true incremental streaming support with progress metadata.
     - Support long-running scans and resumable sessions.
-    - Add pagination metadata consistency and clear `resource_id` semantics.
+    - Preserve stable paging semantics while adding streaming or resumable workflows.
 
 2.  Performance and caching
     - Cache regional analysis results when appropriate.
@@ -61,6 +66,6 @@ This roadmap captures future agent-facing, harness, and feature improvements for
 
 ## Documentation and test coverage
 
-- Keep `AGENTS.md` and `docs/ROADMAP.md` aligned as the source of repo-level policy.
-- Add harness tests in `tests/` for any new agent-facing tool or transport mode.
+- Keep `AGENTS.md`, `README.md`, and `docs/ROADMAP.md` aligned whenever the tool surface changes.
+- Add harness tests in `tests/` for any new agent-facing tool, response contract, or transport mode.
 - Document all new features in `README.md`, `AGENTS.md`, and example scripts.

--- a/src/functions/celestial/impl.py
+++ b/src/functions/celestial/impl.py
@@ -1,8 +1,5 @@
 import asyncio
-from datetime import datetime
 from typing import Any
-
-import pytz
 
 from src.celestial import (
     calculate_moon_info,
@@ -14,7 +11,6 @@ from src.celestial import (
 from src.models import (
     CelestialPosition,
     ConstellationInfo,
-    GeoPoint,
     MoonInfo,
     NightlyForecast,
     RiseSet,
@@ -22,7 +18,15 @@ from src.models import (
 )
 from src.response import MCPError, format_response
 from src.server_instance import mcp
-from src.utils import process_location_and_time
+from src.utils import parse_observation_time, process_location_and_time
+
+
+async def _respond_with_mcp_error(operation) -> dict[str, Any]:
+    """Convert domain validation errors into the standard MCP response shape."""
+    try:
+        return await operation
+    except MCPError as exc:
+        return exc.to_response()
 
 
 @mcp.tool()
@@ -41,12 +45,15 @@ async def get_celestial_pos(
     Returns:
         Dict with keys "data", "_meta". "data" contains "altitude" and "azimuth" (degrees).
     """
-    GeoPoint(lat=lat, lon=lon)  # validate coordinates
-    location, time_info = process_location_and_time(lon, lat, time, time_zone)
-    # Run synchronous celestial calculations in a separate thread to avoid blocking the event loop
-    alt, az = await asyncio.to_thread(celestial_pos, celestial_object, location, time_info)
-    pos = CelestialPosition(altitude=alt, azimuth=az)
-    return format_response(pos.model_dump())
+
+    async def operation() -> dict[str, Any]:
+        location, time_info = process_location_and_time(lon, lat, time, time_zone)
+        # Run synchronous celestial calculations in a thread to avoid blocking the event loop.
+        alt, az = await asyncio.to_thread(celestial_pos, celestial_object, location, time_info)
+        pos = CelestialPosition(altitude=alt, azimuth=az)
+        return format_response(pos.model_dump())
+
+    return await _respond_with_mcp_error(operation())
 
 
 @mcp.tool()
@@ -65,17 +72,20 @@ async def get_celestial_rise_set(
     Returns:
         Dict with keys "data", "_meta". "data" contains "rise_time" and "set_time".
     """
-    GeoPoint(lat=lat, lon=lon)  # validate coordinates
-    location, time_info = process_location_and_time(lon, lat, time, time_zone)
-    # Run synchronous celestial calculations in a separate thread
-    rise_time, set_time = await asyncio.to_thread(
-        celestial_rise_set, celestial_object, location, time_info
-    )
-    rise_set = RiseSet(
-        rise_time=rise_time.isoformat() if rise_time else None,
-        set_time=set_time.isoformat() if set_time else None,
-    )
-    return format_response(rise_set.model_dump())
+
+    async def operation() -> dict[str, Any]:
+        location, time_info = process_location_and_time(lon, lat, time, time_zone)
+        # Run synchronous celestial calculations in a separate thread
+        rise_time, set_time = await asyncio.to_thread(
+            celestial_rise_set, celestial_object, location, time_info
+        )
+        rise_set = RiseSet(
+            rise_time=rise_time.isoformat() if rise_time else None,
+            set_time=set_time.isoformat() if set_time else None,
+        )
+        return format_response(rise_set.model_dump())
+
+    return await _respond_with_mcp_error(operation())
 
 
 @mcp.tool()
@@ -89,27 +99,14 @@ async def get_moon_info(time: str, time_zone: str) -> dict[str, Any]:
     Returns:
         Dict with keys "data", "_meta". "data" contains illumination, phase_name, age_days, etc.
     """
-    try:
-        # Try standard format first
-        dt = datetime.strptime(time, '%Y-%m-%d %H:%M:%S')
-    except ValueError:
-        try:
-            # Try ISO format
-            dt = datetime.fromisoformat(time)
-        except ValueError:
-            raise MCPError(
-                MCPError.INVALID_TIME_FORMAT,
-                f"Time string '{time}' matches neither '%Y-%m-%d %H:%M:%S' nor ISO format.",
-                {'time_string': time, 'expected_formats': ['%Y-%m-%d %H:%M:%S', 'ISO format']},
-            )
 
-    if dt.tzinfo is None:
-        tz = pytz.timezone(time_zone)
-        dt = tz.localize(dt)
+    async def operation() -> dict[str, Any]:
+        dt = parse_observation_time(time, time_zone)
+        result = await asyncio.to_thread(calculate_moon_info, dt)
+        moon_info = MoonInfo(**result)
+        return format_response(moon_info.model_dump())
 
-    result = await asyncio.to_thread(calculate_moon_info, dt)
-    moon_info = MoonInfo(**result)
-    return format_response(moon_info.model_dump())
+    return await _respond_with_mcp_error(operation())
 
 
 @mcp.tool()
@@ -125,14 +122,17 @@ async def list_visible_planets(lon: float, lat: float, time: str, time_zone: str
     Returns:
         Dict with keys "data", "_meta". "data" is a list of planet dicts (name, altitude, azimuth).
     """
-    GeoPoint(lat=lat, lon=lon)  # validate coordinates
-    location, time_info = process_location_and_time(lon, lat, time, time_zone)
-    # Avoid collision with imported function `get_visible_planets` from src.celestial
-    from src.celestial import get_visible_planets as calc_visible_planets
 
-    planets = await asyncio.to_thread(calc_visible_planets, location, time_info)
-    models = [VisiblePlanet(**p) for p in planets]
-    return format_response([m.model_dump() for m in models])
+    async def operation() -> dict[str, Any]:
+        location, time_info = process_location_and_time(lon, lat, time, time_zone)
+        # Avoid collision with imported function `get_visible_planets` from src.celestial
+        from src.celestial import get_visible_planets as calc_visible_planets
+
+        planets = await asyncio.to_thread(calc_visible_planets, location, time_info)
+        models = [VisiblePlanet(**p) for p in planets]
+        return format_response([m.model_dump() for m in models])
+
+    return await _respond_with_mcp_error(operation())
 
 
 # Backwards-compatible alias: export the original name pointing to the decorated wrapper
@@ -155,13 +155,16 @@ async def get_constellation(
     Returns:
         Dict with keys "data", "_meta". "data" contains name, altitude, azimuth.
     """
-    GeoPoint(lat=lat, lon=lon)  # validate coordinates
-    location, time_info = process_location_and_time(lon, lat, time, time_zone)
-    result = await asyncio.to_thread(
-        get_constellation_center, constellation_name, location, time_info
-    )
-    const = ConstellationInfo(**result)
-    return format_response(const.model_dump())
+
+    async def operation() -> dict[str, Any]:
+        location, time_info = process_location_and_time(lon, lat, time, time_zone)
+        result = await asyncio.to_thread(
+            get_constellation_center, constellation_name, location, time_info
+        )
+        const = ConstellationInfo(**result)
+        return format_response(const.model_dump())
+
+    return await _respond_with_mcp_error(operation())
 
 
 @mcp.tool()
@@ -183,17 +186,20 @@ async def get_nightly_forecast(
         - planets: List of visible planets
         - deep_sky: Sorted list of deep sky objects (Messier/NGC)
     """
-    GeoPoint(lat=lat, lon=lon)  # validate coordinates
-    location, time_info = process_location_and_time(lon, lat, time, time_zone)
 
-    # Run in thread
-    result = await asyncio.to_thread(calculate_nightly_forecast, location, time_info, limit)
+    async def operation() -> dict[str, Any]:
+        location, time_info = process_location_and_time(lon, lat, time, time_zone)
 
-    from src.models.celestial import DeepSkyObject
+        # Run in thread
+        result = await asyncio.to_thread(calculate_nightly_forecast, location, time_info, limit)
 
-    forecast = NightlyForecast(
-        moon_phase=MoonInfo(**result['moon_phase']),
-        planets=[VisiblePlanet(**p) for p in result['planets']],
-        deep_sky=[DeepSkyObject(**o) for o in result['deep_sky']],
-    )
-    return format_response(forecast.model_dump())
+        from src.models.celestial import DeepSkyObject
+
+        forecast = NightlyForecast(
+            moon_phase=MoonInfo(**result['moon_phase']),
+            planets=[VisiblePlanet(**p) for p in result['planets']],
+            deep_sky=[DeepSkyObject(**o) for o in result['deep_sky']],
+        )
+        return format_response(forecast.model_dump())
+
+    return await _respond_with_mcp_error(operation())

--- a/src/functions/places/impl.py
+++ b/src/functions/places/impl.py
@@ -10,7 +10,7 @@ from src.models.places import (
     StargazingLocation,
 )
 from src.placefinder import StargazingPlaceFinder, get_light_pollution_grid
-from src.response import format_response
+from src.response import MCPError, format_error, format_response
 from src.server_instance import mcp
 
 
@@ -74,8 +74,21 @@ async def analysis_area(
         - total: Total number of locations found.
         - page: Current page number.
         - page_size: Current page size.
-        - resource_id: Cache key for these search parameters.
+        - resource_id: Cache key for the non-pagination search parameters.
     """
+    if page < 1:
+        return format_error(
+            MCPError.CONFIGURATION_ERROR,
+            'page must be greater than or equal to 1.',
+            {'page': page},
+        )
+    if page_size < 1:
+        return format_error(
+            MCPError.CONFIGURATION_ERROR,
+            'page_size must be greater than or equal to 1.',
+            {'page_size': page_size},
+        )
+
     # 1. Generate Cache Key based on calculation parameters (excluding pagination)
     calc_params = {
         'south': south,
@@ -128,7 +141,7 @@ async def analysis_area(
         total=total,
         page=page,
         page_size=page_size,
-        total_pages=(total + page_size - 1) // page_size if page_size > 0 else 0,
+        total_pages=(total + page_size - 1) // page_size,
         resource_id=resource_id,
     )
     return format_response(result.model_dump())

--- a/src/functions/weather/impl.py
+++ b/src/functions/weather/impl.py
@@ -1,30 +1,86 @@
-from pydantic import BaseModel, Field, field_validator
-
 from src.functions.weather.providers.qweather import get_qweather_auth_from_env
 from src.functions.weather.service import (
     get_aggregated_weather_by_name,
     get_aggregated_weather_by_position,
 )
-from src.models import GeoPoint
 from src.models.weather import AggregatedWeatherResponse
 from src.response import MCPError, format_error, format_response
 from src.retry import RetryConfig, retry_on_failure
 from src.server_instance import mcp
+from src.utils import validate_coordinates
+
+WEATHER_PROVIDERS = {'all', 'qweather', 'open-meteo', 'wttr'}
 
 
-class WeatherQuery(BaseModel):
-    """Validated input for weather queries."""
+def _normalize_provider(provider: str) -> str:
+    """Validate and normalize the provider name."""
+    normalized = provider.strip().lower()
+    if normalized not in WEATHER_PROVIDERS:
+        raise MCPError(
+            MCPError.CONFIGURATION_ERROR,
+            f"Unsupported provider: '{provider}'. Allowed: {sorted(WEATHER_PROVIDERS)}",
+            {'provider': provider},
+        )
+    return normalized
 
-    provider: str = Field(default='all')
 
-    @field_validator('provider')
-    @classmethod
-    def normalize_provider(cls, v: str) -> str:
-        normalized = v.strip().lower()
-        allowed = {'all', 'qweather', 'open-meteo', 'wttr'}
-        if normalized not in allowed:
-            raise ValueError(f"Unsupported provider: '{v}'. Allowed: {sorted(allowed)}")
-        return normalized
+def _normalize_place_name(place_name: str) -> str:
+    """Validate and normalize a place name query."""
+    cleaned_name = place_name.strip()
+    if not cleaned_name:
+        raise MCPError(
+            MCPError.CONFIGURATION_ERROR,
+            'place_name 不能为空。',
+            {'place_name': place_name},
+        )
+    return cleaned_name
+
+
+def _validate_weather_coordinates(lat: float, lon: float) -> None:
+    """Validate latitude and longitude for weather queries."""
+    if not validate_coordinates(lat, lon):
+        raise MCPError(
+            MCPError.INVALID_COORDINATES,
+            f'Invalid coordinates: lat={lat}, lon={lon}',
+            {'lat': lat, 'lon': lon},
+        )
+
+
+def _respond_with_mcp_error(operation):
+    """Convert MCPError exceptions into the standard response payload."""
+    try:
+        return operation()
+    except MCPError as exc:
+        return exc.to_response()
+
+
+def _format_weather_result(result: AggregatedWeatherResponse | dict) -> dict:
+    """Serialize weather results into the standard MCP success payload."""
+    if isinstance(result, AggregatedWeatherResponse):
+        return format_response(result.model_dump())
+    return format_response(result)
+
+
+def _execute_weather_fetch(fetch_weather, error_details: dict) -> dict:
+    """Run a retried weather fetch and translate external failures once."""
+
+    @retry_on_failure(
+        RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
+        retryable_errors=(ConnectionError, TimeoutError, OSError),
+    )
+    def _fetch_weather():
+        return fetch_weather()
+
+    try:
+        return _format_weather_result(_fetch_weather())
+    except MCPError as exc:
+        return exc.to_response()
+    except Exception as exc:
+        return format_error(
+            MCPError.EXTERNAL_API_ERROR,
+            f'天气查询失败: {exc}',
+            error_details,
+        )
 
 
 def _get_qweather_auth_from_env() -> tuple[str | None, str | None, str | None]:
@@ -49,45 +105,16 @@ def get_weather_by_name(place_name: str, provider: str = 'all'):
     Returns:
         Dict，包含 keys: "data", "_meta"（成功时）或 "error", "_meta"（失败时）。
     """
-    cleaned_name = place_name.strip()
-    if not cleaned_name:
-        return format_error(
-            MCPError.CONFIGURATION_ERROR,
-            'place_name 不能为空。',
-            {'place_name': place_name},
-        )
 
-    try:
-        WeatherQuery(provider=provider)  # validates via Pydantic
-    except ValueError as exc:
-        return format_error(
-            MCPError.CONFIGURATION_ERROR,
-            str(exc),
-            {'place_name': cleaned_name, 'provider': provider},
-        )
-
-    try:
-
-        @retry_on_failure(
-            RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
-            retryable_errors=(ConnectionError, TimeoutError, OSError),
-        )
-        def _fetch_weather():
-            return get_aggregated_weather_by_name(cleaned_name, provider=provider)
-
-        result = _fetch_weather()
-    except MCPError as exc:
-        return exc.to_response()
-    except Exception as exc:
-        return format_error(
-            MCPError.EXTERNAL_API_ERROR,
-            f'天气查询失败: {exc}',
+    def operation() -> dict:
+        cleaned_name = _normalize_place_name(place_name)
+        normalized_provider = _normalize_provider(provider)
+        return _execute_weather_fetch(
+            lambda: get_aggregated_weather_by_name(cleaned_name, provider=normalized_provider),
             {'place_name': cleaned_name},
         )
 
-    if isinstance(result, AggregatedWeatherResponse):
-        return format_response(result.model_dump())
-    return format_response(result)
+    return _respond_with_mcp_error(operation)
 
 
 @mcp.tool()
@@ -106,43 +133,13 @@ def get_weather_by_position(lat: float, lon: float, provider: str = 'all'):
     Returns:
         Dict，包含 keys: "data", "_meta"（成功时）或 "error", "_meta"（失败时）。
     """
-    try:
-        GeoPoint(lat=lat, lon=lon)  # validates via Pydantic
-    except ValueError as exc:
-        return format_error(
-            MCPError.INVALID_COORDINATES,
-            str(exc),
+
+    def operation() -> dict:
+        _validate_weather_coordinates(lat, lon)
+        normalized_provider = _normalize_provider(provider)
+        return _execute_weather_fetch(
+            lambda: get_aggregated_weather_by_position(lat, lon, provider=normalized_provider),
             {'lat': lat, 'lon': lon},
         )
 
-    try:
-        WeatherQuery(provider=provider)  # validates via Pydantic
-    except ValueError as exc:
-        return format_error(
-            MCPError.CONFIGURATION_ERROR,
-            str(exc),
-            {'lat': lat, 'lon': lon, 'provider': provider},
-        )
-
-    try:
-
-        @retry_on_failure(
-            RetryConfig(max_attempts=3, base_delay=1.0, max_delay=10.0),
-            retryable_errors=(ConnectionError, TimeoutError, OSError),
-        )
-        def _fetch_weather():
-            return get_aggregated_weather_by_position(lat, lon, provider=provider)
-
-        result = _fetch_weather()
-    except MCPError as exc:
-        return exc.to_response()
-    except Exception as exc:
-        return format_error(
-            MCPError.EXTERNAL_API_ERROR,
-            f'天气查询失败: {exc}',
-            {'lat': lat, 'lon': lon},
-        )
-
-    if isinstance(result, AggregatedWeatherResponse):
-        return format_response(result.model_dump())
-    return format_response(result)
+    return _respond_with_mcp_error(operation)

--- a/src/server_instance.py
+++ b/src/server_instance.py
@@ -7,6 +7,7 @@ FastMCP 服务实例。
   仅满足 `@mcp.tool()` 装饰器与 `.fn` 调用方式（测试用）。
 """
 
+import copy
 import inspect
 from typing import Any
 
@@ -121,7 +122,7 @@ class MCP:
         }
 
     def get_tool_catalog(self):
-        return list(self._tool_metadata.values())
+        return copy.deepcopy(list(self._tool_metadata.values()))
 
     def __getattr__(self, item):
         return getattr(self._mcp, item)

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,6 +23,46 @@ def create_earth_location(lat: float, lon: float, elevation: float = 0.0) -> Ear
     return EarthLocation(lat=lat * u.deg, lon=lon * u.deg, height=elevation * u.m)
 
 
+def parse_time_string(time: str) -> datetime:
+    """Parse a supported observation time string into a datetime object."""
+    parsers = (
+        lambda value: datetime.strptime(value, '%Y-%m-%d %H:%M:%S'),
+        datetime.fromisoformat,
+    )
+    for parser in parsers:
+        try:
+            return parser(time)
+        except ValueError:
+            continue
+
+    raise MCPError(
+        MCPError.INVALID_TIME_FORMAT,
+        f"Time string '{time}' matches neither '%Y-%m-%d %H:%M:%S' nor ISO format.",
+        {'time_string': time, 'expected_formats': ['%Y-%m-%d %H:%M:%S', 'ISO format']},
+    )
+
+
+def ensure_timezone(dt: datetime, time_zone: str) -> datetime:
+    """Attach the requested timezone when the input datetime is naive."""
+    if dt.tzinfo is not None:
+        return dt
+
+    try:
+        time_zone_info = pytz.timezone(time_zone)
+    except pytz.exceptions.UnknownTimeZoneError as exc:
+        raise MCPError(
+            MCPError.INVALID_TIMEZONE,
+            f"Invalid timezone '{time_zone}': {exc}",
+            {'timezone': time_zone},
+        ) from exc
+    return time_zone_info.localize(dt)
+
+
+def parse_observation_time(time: str, time_zone: str) -> datetime:
+    """Parse and normalize an observation timestamp into a timezone-aware datetime."""
+    return ensure_timezone(parse_time_string(time), time_zone)
+
+
 def parse_datetime(date_str: str, time_str: str, timezone: str = 'UTC') -> datetime:
     """
     Parse a date string into a timezone-aware datetime object.
@@ -102,29 +142,5 @@ def process_location_and_time(
     Returns:
         Tuple of (EarthLocation, datetime) objects. datetime is timezone-aware.
     """
-    earth_location = EarthLocation(lon=lon * u.deg, lat=lat * u.deg)
-
-    try:
-        # Try standard format first
-        dt = datetime.strptime(time, '%Y-%m-%d %H:%M:%S')
-    except ValueError:
-        try:
-            # Try ISO format
-            dt = datetime.fromisoformat(time)
-        except ValueError:
-            raise ValueError(
-                f"Time string '{time}' matches neither '%Y-%m-%d %H:%M:%S' nor ISO format."
-            )
-
-    # If datetime is naive, localize it using the provided time_zone
-    if dt.tzinfo is None:
-        time_zone_info = pytz.timezone(time_zone)
-        dt = time_zone_info.localize(dt)
-    else:
-        # If already aware, ensure it's in the requested timezone or leave as is?
-        # Usually we trust the input timezone if provided separately,
-        # but if the string has offset, that takes precedence.
-        # Here we follow the original logic's intent: ensure awareness.
-        pass
-
-    return earth_location, dt
+    earth_location = create_earth_location(lat=lat, lon=lon)
+    return earth_location, parse_observation_time(time, time_zone)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,12 @@ def _initialize_session(host: str, port: int, path: str) -> str:
 
 def _list_tools(host: str, port: int, path: str, session_id: str) -> set[str]:
     """Call MCP ``tools/list`` and return the advertised tool names."""
+    tools = _list_tool_entries(host, port, path, session_id)
+    return {tool['name'] for tool in tools if 'name' in tool}
+
+
+def _list_tool_entries(host: str, port: int, path: str, session_id: str) -> list[dict]:
+    """Call MCP ``tools/list`` and return the advertised tool objects."""
     conn = http.client.HTTPConnection(host, port, timeout=5)
     body = json.dumps({'jsonrpc': '2.0', 'id': 'tools-list', 'method': 'tools/list'})
     headers = {
@@ -98,8 +104,7 @@ def _list_tools(host: str, port: int, path: str, session_id: str) -> set[str]:
     conn.close()
 
     assert 'result' in payload, payload
-    tools = payload['result'].get('tools', [])
-    return {tool['name'] for tool in tools if 'name' in tool}
+    return payload['result'].get('tools', [])
 
 
 def _call_tool(
@@ -126,6 +131,95 @@ def _call_tool(
     payload = _read_jsonrpc_response(response, expected_id=request_id)
     conn.close()
     return payload
+
+
+def _open_sse_stream(
+    host: str, port: int, path: str
+) -> tuple[http.client.HTTPConnection, http.client.HTTPResponse, str]:
+    """Open the SSE endpoint and return the live connection plus the message endpoint path."""
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    conn.request('GET', path, headers={'Accept': 'text/event-stream'})
+    response = conn.getresponse()
+    response.fp.raw._sock.settimeout(5.0)
+
+    assert response.status == 200, response.status
+    assert 'text/event-stream' in response.getheader('Content-Type', '')
+
+    event_name, data = _read_sse_event(response)
+    assert event_name == 'endpoint', (event_name, data)
+    return conn, response, data
+
+
+def _read_sse_event(
+    response: http.client.HTTPResponse, timeout_seconds: float = 5.0
+) -> tuple[str | None, str]:
+    """Read the next complete SSE event from an open stream response."""
+    deadline = time.time() + timeout_seconds
+    event_name = None
+    data_lines: list[str] = []
+
+    while time.time() < deadline:
+        raw_line = response.fp.readline()
+        if not raw_line:
+            continue
+
+        line = raw_line.decode('utf-8', errors='replace').rstrip('\r\n')
+        if not line:
+            if data_lines:
+                return event_name, '\n'.join(data_lines)
+            event_name = None
+            data_lines = []
+            continue
+
+        if line.startswith('event:'):
+            event_name = line[6:].strip()
+        elif line.startswith('data:'):
+            data_lines.append(line[5:].strip())
+
+    raise AssertionError('Timed out while reading SSE event from server.')
+
+
+def _read_sse_jsonrpc_payload(
+    response: http.client.HTTPResponse,
+    expected_id: str | None = None,
+    timeout_seconds: float = 5.0,
+) -> dict:
+    """Read JSON-RPC payloads from an open SSE stream and optionally match on request id."""
+    deadline = time.time() + timeout_seconds
+
+    while time.time() < deadline:
+        _, data = _read_sse_event(response, timeout_seconds=max(0.1, deadline - time.time()))
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+
+        if 'result' not in payload and 'error' not in payload:
+            continue
+        if expected_id is not None and payload.get('id') != expected_id:
+            continue
+        return payload
+
+    raise AssertionError(f'No JSON-RPC payload found in SSE stream for id={expected_id}.')
+
+
+def _post_sse_jsonrpc(host: str, port: int, message_path: str, payload: dict) -> int:
+    """Post a JSON-RPC message to the SSE message endpoint and return the HTTP status."""
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    conn.request(
+        'POST',
+        message_path,
+        body=json.dumps(payload),
+        headers={
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream',
+        },
+    )
+    response = conn.getresponse()
+    status = response.status
+    response.read()
+    conn.close()
+    return status
 
 
 def _wait_for_server(host: str, port: int, path: str, timeout_seconds: float) -> str:
@@ -161,6 +255,51 @@ def running_mcp_server() -> Generator[tuple[str, int, str, str]]:
         session_id = _wait_for_server(host, port, path, timeout_seconds=20.0)
         yield host, port, path, session_id
     finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - cleanup fallback
+            process.kill()
+            process.wait(timeout=5)
+
+
+@pytest.fixture
+def running_mcp_sse_server() -> Generator[
+    tuple[str, int, str, http.client.HTTPResponse, http.client.HTTPConnection]
+]:
+    """Start the real MCP SSE server process and yield connection info for protocol tests."""
+    host = '127.0.0.1'
+    port = _get_free_port()
+    path = '/sse'
+    process = subprocess.Popen(
+        [sys.executable, '-m', 'src.main', '--mode', 'sse', '--port', str(port), '--path', path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+    )
+
+    stream_conn = None
+    stream_response = None
+    try:
+        deadline = time.time() + 20.0
+        last_error: Exception | None = None
+        message_path = ''
+
+        while time.time() < deadline:
+            try:
+                stream_conn, stream_response, message_path = _open_sse_stream(host, port, path)
+                break
+            except Exception as exc:  # pragma: no cover - timing dependent branch
+                last_error = exc
+                time.sleep(0.2)
+        else:
+            raise AssertionError(f'MCP SSE server failed to start within timeout: {last_error}')
+
+        yield host, port, message_path, stream_response, stream_conn
+    finally:
+        if stream_conn is not None:
+            stream_conn.close()
         process.terminate()
         try:
             process.wait(timeout=5)

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -6,7 +6,13 @@ import json
 from datetime import datetime
 
 import pytest
-from conftest import _call_tool, _list_tools
+from conftest import (
+    _call_tool,
+    _list_tool_entries,
+    _list_tools,
+    _post_sse_jsonrpc,
+    _read_sse_jsonrpc_payload,
+)
 
 EXPECTED_TOOLS = {
     'analysis_area',
@@ -134,6 +140,111 @@ def test_tools_call_get_tool_catalog_returns_expected_tools(running_mcp_server):
     assert weather_tool['description'] == '通过地点名称获取综合天气（当前 + 小时预报 + 日预报）。'
     assert any(param['name'] == 'place_name' for param in weather_tool['parameters'])
     assert any(param['name'] == 'provider' for param in weather_tool['parameters'])
+
+
+def test_tools_list_matches_get_tool_catalog_names(running_mcp_server):
+    """`tools/list` and `get_tool_catalog` should expose the same registered tool names."""
+    host, port, path, session_id = running_mcp_server
+    listed_tools = _list_tools(host, port, path, session_id)
+    payload = _call_tool(host, port, path, session_id, 'get_tool_catalog', {})
+
+    catalog_data = _assert_success_tool_payload(payload, expected_id='call-get_tool_catalog')
+    catalog_tools = catalog_data['tools']
+
+    assert {tool['name'] for tool in catalog_tools} == listed_tools
+
+
+def test_tools_list_matches_get_tool_catalog_descriptions_and_parameters(running_mcp_server):
+    """`tools/list` should stay aligned with the wrapped catalog descriptions and parameters."""
+    host, port, path, session_id = running_mcp_server
+    listed_tools = _list_tool_entries(host, port, path, session_id)
+    payload = _call_tool(host, port, path, session_id, 'get_tool_catalog', {})
+
+    catalog_data = _assert_success_tool_payload(payload, expected_id='call-get_tool_catalog')
+    catalog_by_name = {tool['name']: tool for tool in catalog_data['tools']}
+    listed_by_name = {tool['name']: tool for tool in listed_tools}
+
+    assert set(listed_by_name) == set(catalog_by_name)
+
+    for tool_name, catalog_tool in catalog_by_name.items():
+        listed_tool = listed_by_name[tool_name]
+        assert listed_tool['description'].startswith(catalog_tool['description'])
+
+        input_schema = listed_tool.get('inputSchema', {})
+        properties = input_schema.get('properties', {})
+        required = set(input_schema.get('required', []))
+        catalog_parameter_names = {param['name'] for param in catalog_tool['parameters']}
+        catalog_required_names = {
+            param['name'] for param in catalog_tool['parameters'] if param['required']
+        }
+
+        assert set(properties) == catalog_parameter_names
+        assert required == catalog_required_names
+
+
+def test_sse_tools_call_preserves_request_id(running_mcp_sse_server):
+    """SSE responses should preserve the JSON-RPC request id for initialize and tool calls."""
+    host, port, message_path, stream_response, _stream_conn = running_mcp_sse_server
+
+    initialize_status = _post_sse_jsonrpc(
+        host,
+        port,
+        message_path,
+        {
+            'jsonrpc': '2.0',
+            'id': 'sse-init',
+            'method': 'initialize',
+            'params': {
+                'clientInfo': {'name': 'pytest-sse-client', 'version': '1.0'},
+                'capabilities': {},
+                'protocolVersion': '2024-11-05',
+            },
+        },
+    )
+    assert initialize_status == 202
+
+    initialize_payload = _read_sse_jsonrpc_payload(stream_response, expected_id='sse-init')
+    assert initialize_payload['id'] == 'sse-init'
+    assert 'result' in initialize_payload
+
+    tool_status = _post_sse_jsonrpc(
+        host,
+        port,
+        message_path,
+        {'jsonrpc': '2.0', 'id': 'sse-tools-list', 'method': 'tools/list'},
+    )
+    assert tool_status == 202
+
+    tools_payload = _read_sse_jsonrpc_payload(stream_response, expected_id='sse-tools-list')
+    assert tools_payload['id'] == 'sse-tools-list'
+    assert 'result' in tools_payload
+    assert {tool['name'] for tool in tools_payload['result'].get('tools', [])} == EXPECTED_TOOLS
+
+
+def test_tools_call_business_error_returns_structured_error_payload(running_mcp_server):
+    """Business validation failures should stay in structuredContent, not JSON-RPC errors."""
+    host, port, path, session_id = running_mcp_server
+    payload = _call_tool(
+        host,
+        port,
+        path,
+        session_id,
+        'get_moon_info',
+        {'time': 'invalid-time-format', 'time_zone': 'UTC'},
+    )
+
+    assert payload['jsonrpc'] == '2.0'
+    assert payload['id'] == 'call-get_moon_info'
+    assert 'error' not in payload, payload
+    assert 'result' in payload, payload
+
+    result = payload['result']
+    assert result['isError'] is False
+    structured_content = result['structuredContent']
+    assert structured_content['_meta']['status'] == 'error'
+    assert structured_content['error']['code'] == 'INVALID_TIME_FORMAT'
+    assert 'invalid-time-format' in structured_content['error']['message']
+    assert json.loads(result['content'][0]['text']) == structured_content
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -175,6 +175,25 @@ async def test_get_moon_info_iso_format():
     assert result['data']['illumination'] == 0.25
 
 
+@pytest.mark.asyncio
+async def test_get_moon_info_naive_time_localizes_timezone():
+    """``get_moon_info.fn`` should localize naive timestamps with the provided timezone."""
+    with patch('src.functions.celestial.impl.calculate_moon_info') as mock_calc:
+        mock_calc.return_value = {
+            'phase_name': 'First Quarter',
+            'illumination': 0.5,
+            'age_days': 7.0,
+            'elongation': 90.0,
+            'earth_distance': 384400.0,
+        }
+
+        result = await get_moon_info.fn(time='2024-06-15 12:00:00', time_zone='UTC')
+
+    assert result['_meta']['status'] == 'success'
+    assert result['data']['phase_name'] == 'First Quarter'
+    assert result['data']['illumination'] == 0.5
+
+
 # ---------------------------------------------------------------------------
 # Time tool
 # ---------------------------------------------------------------------------

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
 import pytz
 
 from src.functions.celestial.impl import get_celestial_pos, get_celestial_rise_set
@@ -129,3 +130,156 @@ def test_analysis_area_pagination_serialization():
             assert MockPF.call_count == 1
 
     asyncio.run(run_test())
+
+
+@pytest.mark.asyncio
+async def test_analysis_area_resource_id_is_stable_across_pages():
+    """The same non-pagination query should reuse the same cached resource identifier."""
+
+    class MockCache:
+        def __init__(self):
+            self.store = {}
+
+        def get(self, key):
+            return self.store.get(key)
+
+        def set(self, key, value):
+            self.store[key] = value
+
+    with (
+        patch('src.functions.places.impl.StargazingPlaceFinder') as mock_placefinder,
+        patch('src.functions.places.impl.ANALYSIS_CACHE', new=MockCache()),
+    ):
+        mock_placefinder.return_value.analyze_area.return_value = [
+            {'name': f'Loc {i}', 'score': i, 'lat': 35.0 + i * 0.01, 'lon': -120.0 - i * 0.01}
+            for i in range(12)
+        ]
+
+        result_page_1 = await analysis_area.fn(
+            south=30.0,
+            west=100.0,
+            north=31.0,
+            east=101.0,
+            page=1,
+            page_size=5,
+        )
+        result_page_2 = await analysis_area.fn(
+            south=30.0,
+            west=100.0,
+            north=31.0,
+            east=101.0,
+            page=2,
+            page_size=5,
+        )
+
+    assert result_page_1['_meta']['status'] == 'success'
+    assert result_page_2['_meta']['status'] == 'success'
+    assert result_page_1['data']['resource_id'] == result_page_2['data']['resource_id']
+    assert mock_placefinder.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_analysis_area_resource_id_changes_with_calc_params():
+    """Changing a calculation parameter should produce a distinct resource identifier."""
+
+    class MockCache:
+        def get(self, key):
+            return None
+
+        def set(self, key, value):
+            return None
+
+    with (
+        patch('src.functions.places.impl.StargazingPlaceFinder') as mock_placefinder,
+        patch('src.functions.places.impl.ANALYSIS_CACHE', new=MockCache()),
+    ):
+        mock_placefinder.return_value.analyze_area.return_value = []
+
+        result_a = await analysis_area.fn(
+            south=30.0,
+            west=100.0,
+            north=31.0,
+            east=101.0,
+            min_height_diff=100.0,
+        )
+        result_b = await analysis_area.fn(
+            south=30.0,
+            west=100.0,
+            north=31.0,
+            east=101.0,
+            min_height_diff=150.0,
+        )
+
+    assert result_a['_meta']['status'] == 'success'
+    assert result_b['_meta']['status'] == 'success'
+    assert result_a['data']['resource_id'] != result_b['data']['resource_id']
+
+
+@pytest.mark.asyncio
+async def test_analysis_area_returns_empty_items_for_out_of_range_page():
+    """Out-of-range pages should remain successful and return an empty item list."""
+
+    class MockCache:
+        def __init__(self):
+            self.store = {}
+
+        def get(self, key):
+            return self.store.get(key)
+
+        def set(self, key, value):
+            self.store[key] = value
+
+    with (
+        patch('src.functions.places.impl.StargazingPlaceFinder') as mock_placefinder,
+        patch('src.functions.places.impl.ANALYSIS_CACHE', new=MockCache()),
+    ):
+        mock_placefinder.return_value.analyze_area.return_value = [
+            {'name': f'Loc {i}', 'score': i, 'lat': 35.0 + i * 0.01, 'lon': -120.0 - i * 0.01}
+            for i in range(3)
+        ]
+
+        result = await analysis_area.fn(
+            south=30.0,
+            west=100.0,
+            north=31.0,
+            east=101.0,
+            page=5,
+            page_size=2,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    assert result['data']['items'] == []
+    assert result['data']['total'] == 3
+    assert result['data']['total_pages'] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('field_name', 'field_value', 'expected_message'),
+    [
+        ('page', 0, 'page must be greater than or equal to 1.'),
+        ('page_size', 0, 'page_size must be greater than or equal to 1.'),
+    ],
+)
+async def test_analysis_area_rejects_invalid_pagination_inputs(
+    field_name: str,
+    field_value: int,
+    expected_message: str,
+):
+    """Invalid pagination inputs should return the standard structured error payload."""
+    kwargs = {
+        'south': 30.0,
+        'west': 100.0,
+        'north': 31.0,
+        'east': 101.0,
+        'page': 1,
+        'page_size': 10,
+    }
+    kwargs[field_name] = field_value
+
+    result = await analysis_area.fn(**kwargs)
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == 'CONFIGURATION_ERROR'
+    assert result['error']['message'] == expected_message
+    assert result['error']['details'] == {field_name: field_value}

--- a/tests/test_server_instance.py
+++ b/tests/test_server_instance.py
@@ -188,7 +188,7 @@ def test_get_tool_catalog_returns_list():
 
 
 def test_get_tool_catalog_is_a_copy():
-    """Modifying the returned list does not affect internal metadata."""
+    """Modifying the returned catalog should not affect internal metadata."""
     fresh_mcp = MCP('test-server')
 
     @fresh_mcp.tool()
@@ -200,6 +200,24 @@ def test_get_tool_catalog_is_a_copy():
     catalog.clear()
     # Internal metadata should be unaffected
     assert len(fresh_mcp.get_tool_catalog()) == 1
+
+
+def test_get_tool_catalog_returns_deep_copy_entries():
+    """Mutating nested metadata in the returned catalog must not leak back into the MCP wrapper."""
+    fresh_mcp = MCP('test-server')
+
+    @fresh_mcp.tool()
+    def nested_tool(query: str, limit: int = 10) -> dict[str, Any]:
+        """Nested metadata tool."""
+        return {'query': query, 'limit': limit}
+
+    catalog = fresh_mcp.get_tool_catalog()
+    catalog[0]['description'] = 'mutated'
+    catalog[0]['parameters'][0]['name'] = 'changed'
+
+    internal_catalog = fresh_mcp.get_tool_catalog()
+    assert internal_catalog[0]['description'] == 'Nested metadata tool.'
+    assert internal_catalog[0]['parameters'][0]['name'] == 'query'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_structured_errors.py
+++ b/tests/test_structured_errors.py
@@ -2,7 +2,14 @@ from unittest.mock import patch
 
 import pytest
 
-from src.functions.celestial.impl import get_moon_info
+from src.functions.celestial.impl import (
+    get_celestial_pos,
+    get_celestial_rise_set,
+    get_constellation,
+    get_moon_info,
+    get_nightly_forecast,
+    list_visible_planets,
+)
 from src.functions.weather.impl import (
     _get_qweather_auth_from_env,
     get_weather_by_name,
@@ -69,19 +76,114 @@ def test_invalid_timezone_error():
 
 
 def test_invalid_time_format_error():
-    """Test that invalid time format raises MCPError."""
+    """Test that invalid time format returns a structured MCP error response."""
 
     async def run_test():
-        with pytest.raises(MCPError) as exc_info:
-            await get_moon_info.fn('invalid-time-format', 'UTC')
+        result = await get_moon_info.fn('invalid-time-format', 'UTC')
 
-        error = exc_info.value
-        assert error.code == MCPError.INVALID_TIME_FORMAT
-        assert 'invalid-time-format' in error.message
+        assert result['_meta']['status'] == 'error'
+        assert result['error']['code'] == MCPError.INVALID_TIME_FORMAT
+        assert 'invalid-time-format' in result['error']['message']
 
     import asyncio
 
     asyncio.run(run_test())
+
+
+@pytest.mark.asyncio
+async def test_celestial_position_invalid_coordinates_return_structured_error():
+    """Coordinate validation for celestial tools should return the business error shape."""
+    result = await get_celestial_pos.fn(
+        celestial_object='sun',
+        lon=181.0,
+        lat=40.0,
+        time='2024-06-15 12:00:00',
+        time_zone='UTC',
+    )
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_COORDINATES
+    assert result['error']['details']['lon'] == 181.0
+
+
+@pytest.mark.asyncio
+async def test_celestial_position_invalid_timezone_returns_structured_error():
+    """Timezone validation for celestial tools should return the business error shape."""
+    with patch('src.functions.celestial.impl.celestial_pos', return_value=(10.0, 120.0)):
+        result = await get_celestial_pos.fn(
+            celestial_object='sun',
+            lon=120.0,
+            lat=30.0,
+            time='2024-06-15 12:00:00',
+            time_zone='Invalid/Timezone',
+        )
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_TIMEZONE
+    assert result['error']['details']['timezone'] == 'Invalid/Timezone'
+
+
+@pytest.mark.asyncio
+async def test_moon_info_invalid_timezone_returns_structured_error():
+    """Moon info should translate invalid timezones into the standard error payload."""
+    result = await get_moon_info.fn('2024-06-15 12:00:00', 'Invalid/Timezone')
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_TIMEZONE
+    assert result['error']['details']['timezone'] == 'Invalid/Timezone'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'tool_fn, kwargs',
+    [
+        (
+            get_celestial_rise_set,
+            {
+                'celestial_object': 'sun',
+                'lon': 181.0,
+                'lat': 40.0,
+                'time': '2024-06-15 12:00:00',
+                'time_zone': 'UTC',
+            },
+        ),
+        (
+            list_visible_planets,
+            {
+                'lon': 181.0,
+                'lat': 40.0,
+                'time': '2024-06-15 12:00:00',
+                'time_zone': 'UTC',
+            },
+        ),
+        (
+            get_constellation,
+            {
+                'constellation_name': 'Orion',
+                'lon': 181.0,
+                'lat': 40.0,
+                'time': '2024-06-15 12:00:00',
+                'time_zone': 'UTC',
+            },
+        ),
+        (
+            get_nightly_forecast,
+            {
+                'lon': 181.0,
+                'lat': 40.0,
+                'time': '2024-06-15 12:00:00',
+                'time_zone': 'UTC',
+            },
+        ),
+    ],
+)
+async def test_other_celestial_tools_invalid_coordinates_return_structured_error(tool_fn, kwargs):
+    """All celestial tools should normalize coordinate failures into business error payloads."""
+    result = await tool_fn.fn(**kwargs)
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_COORDINATES
+    assert result['error']['details']['lon'] == 181.0
 
 
 @patch.dict('os.environ', {}, clear=True)

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -1,5 +1,7 @@
 import src.functions.celestial.impl  # noqa: F401
 import src.functions.metadata.impl  # noqa: F401
+import src.functions.places.impl  # noqa: F401
+import src.functions.weather.impl  # noqa: F401
 from src.server_instance import mcp
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,13 @@ import pytz
 from astropy.coordinates import EarthLocation
 
 from src.response import MCPError
-from src.utils import create_earth_location, localtime_to_utc, parse_datetime, validate_coordinates
+from src.utils import (
+    create_earth_location,
+    localtime_to_utc,
+    parse_datetime,
+    process_location_and_time,
+    validate_coordinates,
+)
 
 UTC = pytz.timezone('UTC')
 
@@ -42,6 +48,13 @@ def test_localtime_to_utc():
     assert utc_dt.hour == local_dt.hour
     with pytest.raises(MCPError):
         localtime_to_utc(datetime(2023, 10, 1))
+
+
+def test_process_location_and_time_invalid_time_raises_mcperror():
+    with pytest.raises(MCPError) as exc_info:
+        process_location_and_time(lon=116.0, lat=40.0, time='invalid-time', time_zone='UTC')
+
+    assert exc_info.value.code == MCPError.INVALID_TIME_FORMAT
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- tighten `analysis_area` pagination and `resource_id` contract semantics
- align tool metadata, `tools/list`, and SSE request-id protocol coverage
- simplify celestial and weather error handling into shared boundary helpers

## Testing
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run bandit -c pyproject.toml -r src/
- uv run pytest -v --cov=src --cov-report=xml:cache/coverage.xml
- uvx diff-cover cache/coverage.xml --compare-branch=origin/main --fail-under=100