### PR TITLE
feat: pass SPF config through to RoadConnectivityChecker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "rasterio",
     "tzlocal",
     "geopy",
-    "stargazing-place-finder>=0.6.3,<1",
+    "stargazing-place-finder>=0.6.6,<1",
 ]
 
 [project.scripts]

--- a/src/placefinder.py
+++ b/src/placefinder.py
@@ -77,11 +77,21 @@ class StargazingPlaceFinder:
         if _last_params == new_params:
             return  # nothing changed — reuse the existing singleton
 
+        # Load SPF config from TOML file (env STARGAZING_CONFIG or default path),
+        # then pass it through to RoadConnectivityChecker (tile size, etc.).
+        try:
+            from config import load_stargazing_config  # type: ignore[import-untyped]
+
+            spf_config = load_stargazing_config()
+        except Exception:
+            spf_config = None
+
         self._spf.init_stargazing_analyzer(
             geotiff_path=self.geotiff_path,
             min_height_difference=self.min_height_difference,
             road_search_radius_km=self.road_search_radius_km,
             db_config_path=self.db_config_path,
+            config=spf_config,
         )
         _last_params = new_params
 

--- a/tests/test_placefinder.py
+++ b/tests/test_placefinder.py
@@ -49,6 +49,7 @@ def test_init_uses_dependency_analyzer_factory():
         min_height_difference=100.0,
         road_search_radius_km=10.0,
         db_config_path=None,
+        config=None,
     )
 
 
@@ -182,6 +183,7 @@ def test_init_with_db_config_path_forwards_path():
         min_height_difference=100.0,
         road_search_radius_km=10.0,
         db_config_path=db_config_path,
+        config=None,
     )
 
 


### PR DESCRIPTION
## Summary

Plumb SPF's `StargazingConfig` through from MCP to SPF so users can tune `road_network_tile_max_area_km2` and other parameters.

## How it works

`_init_analyzer()` now calls SPF's `load_stargazing_config()` (which reads `STARGAZING_CONFIG` env var or `config/stargazing_config.toml` from the package), and passes the result to `init_stargazing_analyzer(config=...)`.

This flows through to `RoadConnectivityChecker`, allowing users to adjust:

```toml
# config/stargazing_config.toml
road_network_tile_max_area_km2 = 500.0
```

## Usage

```bash
export STARGAZING_CONFIG=/path/to/stargazing_config.toml
mcp-stargazing ...
```

Depends on: https://github.com/StarGazer1995/stargazing-place-finder/pull/55

🤖 Generated with [Claude Code](https://claude.com/claude-code)