### PR TITLE
fix: sync get_weather_by_position in asyncio.gather via to_thread, fix tests + bump v0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-stargazing"
-version = "0.5.0"
+version = "0.5.1"
 description = "An MCP server that provides real-time astronomical data, smart stargazing planning, and light pollution analysis for AI agents."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/functions/planning/impl.py
+++ b/src/functions/planning/impl.py
@@ -243,7 +243,12 @@ async def _evaluate_candidate(
 ) -> PlannedLocationCandidate:
     """Evaluate one candidate place by attaching weather and target summaries."""
     weather_result, forecast_result = await asyncio.gather(
-        get_weather_by_position.fn(lat=location.lat, lon=location.lon, provider=weather_provider),
+        asyncio.to_thread(
+            get_weather_by_position.fn,
+            lat=location.lat,
+            lon=location.lon,
+            provider=weather_provider,
+        ),
         get_nightly_forecast.fn(
             lon=location.lon, lat=location.lat, time=time, time_zone=time_zone, limit=target_limit
         ),

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -74,75 +74,49 @@ async def test_get_best_stargazing_plan_fn():
             }
         )
         mock_weather.fn = Mock(
-            side_effect=[
-                {
-                    'data': {
-                        'summary': {
-                            'current': {
-                                'weather_text': 'Clear',
-                                'cloud_cover_percent': 12.0,
-                                'visibility_km': 22.0,
-                                'wind_speed_kph': 8.0,
-                            },
-                            'hourly': [
-                                {
-                                    'time': '2024-06-15T21:00:00+08:00',
-                                    'cloud_cover_percent': 10.0,
-                                    'precipitation_probability': 0.0,
-                                    'wind_speed_kph': 7.0,
-                                    'weather_text': 'Clear',
-                                }
-                            ],
-                        }
-                    },
-                    '_meta': {'status': 'success'},
+            side_effect=lambda lat, lon, provider: {
+                'data': {
+                    'summary': {
+                        'current': {
+                            'weather_text': 'Clear' if lat == 40.1 else 'Partly cloudy',
+                            'cloud_cover_percent': 12.0 if lat == 40.1 else 35.0,
+                            'visibility_km': 22.0 if lat == 40.1 else 16.0,
+                            'wind_speed_kph': 8.0 if lat == 40.1 else 12.0,
+                        },
+                        'hourly': [
+                            {
+                                'time': '2024-06-15T21:00:00+08:00'
+                                if lat == 40.1
+                                else '2024-06-15T22:00:00+08:00',
+                                'cloud_cover_percent': 10.0 if lat == 40.1 else 28.0,
+                                'precipitation_probability': 0.0 if lat == 40.1 else 0.1,
+                                'wind_speed_kph': 7.0 if lat == 40.1 else 10.0,
+                                'weather_text': 'Clear' if lat == 40.1 else 'Partly cloudy',
+                            }
+                        ],
+                    }
                 },
-                {
-                    'data': {
-                        'summary': {
-                            'current': {
-                                'weather_text': 'Partly cloudy',
-                                'cloud_cover_percent': 35.0,
-                                'visibility_km': 16.0,
-                                'wind_speed_kph': 12.0,
-                            },
-                            'hourly': [
-                                {
-                                    'time': '2024-06-15T22:00:00+08:00',
-                                    'cloud_cover_percent': 28.0,
-                                    'precipitation_probability': 0.1,
-                                    'wind_speed_kph': 10.0,
-                                    'weather_text': 'Partly cloudy',
-                                }
-                            ],
-                        }
-                    },
-                    '_meta': {'status': 'success'},
-                },
-            ]
+                '_meta': {'status': 'success'},
+            }
         )
         mock_forecast.fn = AsyncMock(
-            side_effect=[
-                {
-                    'data': {
-                        'moon_phase': {'phase_name': 'New Moon', 'illumination': 0.1},
-                        'planets': [{'name': 'Jupiter'}],
-                        'deep_sky': [
+            side_effect=lambda lon, lat, time, time_zone, limit: {
+                'data': {
+                    'moon_phase': {'phase_name': 'New Moon', 'illumination': 0.1}
+                    if lat == 40.1
+                    else {'phase_name': 'First Quarter', 'illumination': 0.5},
+                    'planets': [{'name': 'Jupiter'}] if lat == 40.1 else [{'name': 'Mars'}],
+                    'deep_sky': (
+                        [
                             {'name': 'M31', 'type': 'galaxy', 'score': 91.0},
                             {'name': 'M45', 'type': 'cluster', 'score': 82.0},
-                        ],
-                    },
-                    '_meta': {'status': 'success'},
+                        ]
+                        if lat == 40.1
+                        else [{'name': 'M13', 'type': 'cluster', 'score': 78.0}]
+                    ),
                 },
-                {
-                    'data': {
-                        'moon_phase': {'phase_name': 'First Quarter', 'illumination': 0.5},
-                        'planets': [{'name': 'Mars'}],
-                        'deep_sky': [{'name': 'M13', 'type': 'cluster', 'score': 78.0}],
-                    },
-                    '_meta': {'status': 'success'},
-                },
-            ]
+                '_meta': {'status': 'success'},
+            }
         )
 
         result = await get_best_stargazing_plan.fn(

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,7 +1,7 @@
 """Tests for MCP tool wrappers not covered by other test files."""
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -73,7 +73,7 @@ async def test_get_best_stargazing_plan_fn():
                 '_meta': {'status': 'success'},
             }
         )
-        mock_weather.fn = AsyncMock(
+        mock_weather.fn = Mock(
             side_effect=[
                 {
                     'data': {
@@ -200,7 +200,7 @@ async def test_get_best_stargazing_plan_keeps_partial_results_when_weather_fails
                 '_meta': {'status': 'success'},
             }
         )
-        mock_weather.fn = AsyncMock(
+        mock_weather.fn = Mock(
             return_value={
                 'error': {'code': 'EXTERNAL_API_ERROR', 'message': '天气查询失败: timeout'},
                 '_meta': {'status': 'error'},

--- a/tests/test_placefinder.py
+++ b/tests/test_placefinder.py
@@ -43,7 +43,7 @@ def test_init_uses_dependency_analyzer_factory():
 
     with (
         patch.object(placefinder_module, '_load_spf', return_value=fake_spf),
-        patch('config.load_stargazing_config', return_value=None),
+        patch('config.load_stargazing_config', return_value=None, create=True),
     ):
         StargazingPlaceFinder()
 
@@ -179,7 +179,7 @@ def test_init_with_db_config_path_forwards_path():
 
     with (
         patch.object(placefinder_module, '_load_spf', return_value=fake_spf),
-        patch('config.load_stargazing_config', return_value=None),
+        patch('config.load_stargazing_config', return_value=None, create=True),
     ):
         pf = StargazingPlaceFinder(db_config_path=db_config_path)
 

--- a/tests/test_placefinder.py
+++ b/tests/test_placefinder.py
@@ -41,7 +41,10 @@ def test_init_uses_dependency_analyzer_factory():
     mock_analyzer = MagicMock()
     fake_spf = _make_fake_spf(mock_analyzer)
 
-    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+    with (
+        patch.object(placefinder_module, '_load_spf', return_value=fake_spf),
+        patch('config.load_stargazing_config', return_value=None),
+    ):
         StargazingPlaceFinder()
 
     fake_spf.init_stargazing_analyzer.assert_called_once_with(
@@ -174,7 +177,10 @@ def test_init_with_db_config_path_forwards_path():
     fake_spf = _make_fake_spf(mock_analyzer)
     db_config_path = Path('/tmp/db_config.json')
 
-    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+    with (
+        patch.object(placefinder_module, '_load_spf', return_value=fake_spf),
+        patch('config.load_stargazing_config', return_value=None),
+    ):
         pf = StargazingPlaceFinder(db_config_path=db_config_path)
 
     assert pf.db_config_path == db_config_path

--- a/uv.lock
+++ b/uv.lock
@@ -1839,7 +1839,7 @@ wheels = [
 
 [[package]]
 name = "mcp-stargazing"
-version = "0.4.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "astropy", extra = ["all"] },
@@ -1874,7 +1874,7 @@ requires-dist = [
     { name = "pytz" },
     { name = "rasterio" },
     { name = "requests" },
-    { name = "stargazing-place-finder", specifier = ">=0.6.3,<1" },
+    { name = "stargazing-place-finder", specifier = ">=0.6.6,<1" },
     { name = "tzlocal" },
 ]
 
@@ -3375,7 +3375,7 @@ wheels = [
 
 [[package]]
 name = "stargazing-place-finder"
-version = "0.6.3"
+version = "0.6.6"
 source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "flask" },
@@ -3394,9 +3394,9 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
 ]
-sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/96/10/3e5bddff084f6fc56707571c44eba17055a42d58f8e730a6cbfd1cb37464/stargazing_place_finder-0.6.3.tar.gz", hash = "sha256:2848debf805487d9d7ce65d7ec46e6ae0a53d1d08953a955b264c8af0adb5c28", size = 73307184 }
+sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/29/a1/c6b91d7e288b2d86644539bda0f636e619f853f0d0632f7ffe72990feb29/stargazing_place_finder-0.6.6.tar.gz", hash = "sha256:6cef716221353175eaf97edfb8fa55ae045aa860f60bc3756413f35e483f09aa", size = 73310398 }
 wheels = [
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/36/e9/95746112ca2c089fa34b8be4d5199823d3a37828b2cfa85a19ee854175f2/stargazing_place_finder-0.6.3-py3-none-any.whl", hash = "sha256:143402d79ac23cb4f5f49199a5067f1b8ac76c04c67e576ef7f86a4dd8ab2a72", size = 73325666 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/2d/21/8fa21d13642aa4174bf481f1045a1c1cce6c679d248c58fb57e2e7df0f09/stargazing_place_finder-0.6.6-py3-none-any.whl", hash = "sha256:ee6740ecaaf721f53fdabf5260d4abe2061152dd96cff0e9c864c632b8a82765", size = 73329178 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes a bug where `get_weather_by_position.fn` (a **sync** function) was called directly inside `asyncio.gather` alongside `get_nightly_forecast.fn` (an **async** function), causing `TypeError: unhashable type: 'dict'`.

## Root Cause

| Function | Definition | Return when called |
|:---|:---:|:---|
| `get_weather_by_position.fn` | `def` (sync) | `dict` |
| `get_nightly_forecast.fn` | `async def` | `coroutine` |

In `_evaluate_candidate`, `asyncio.gather` received a plain `dict` from the sync call instead of a coroutine, and tried to use it as a key in an internal mapping — but `dict` is unhashable.

## Changes

- **`planning/impl.py`**: Wrap `get_weather_by_position.fn(...)` with `asyncio.to_thread()` so it returns a proper awaitable
- **`test_mcp_tools.py`**: Change `mock_weather.fn = AsyncMock(...)` → `Mock(...)` to match the synchronous call pattern
- **`test_placefinder.py`**: Mock `config.load_stargazing_config` to return `None` in two tests that were previously passing by accident
- **`pyproject.toml`**: Bump version 0.5.0 → 0.5.1

## Test Results

```
207 passed, 2 warnings in 18.89s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)