### PR TITLE
docs: add geocoding disambiguation guidance to get_weather_by_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-stargazing"
-version = "0.6.0"
+version = "0.6.1"
 description = "An MCP server that provides real-time astronomical data, smart stargazing planning, and light pollution analysis for AI agents."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/functions/weather/impl.py
+++ b/src/functions/weather/impl.py
@@ -96,12 +96,16 @@ def get_weather_by_name(place_name: str, provider: str = 'all'):
     """
     通过地点名称获取综合天气（当前 + 小时预报 + 日预报）。
 
-    Geocoding uses Nominatim (free).  Weather data is aggregated from
-    multiple providers with graceful fallback — open-meteo is always
-    available without an API key.
+    Geocoding uses Amap (CJK) → Photon → Nominatim cascade.
+    Weather data is aggregated from multiple providers with graceful
+    fallback — open-meteo is always available without an API key.
+
+    **中文地名提示**：短地名（如 "安吉"）可能被解析到同名小村落而非知名城市。
+    建议使用完整行政区划名称，如 "浙江安吉"、"杭州西湖区"。
+    需要精确定位时优先使用 ``get_weather_by_position(lat, lon)``。
 
     Args:
-        place_name: 地点名称（例如城市/区县）。
+        place_name: 地点名称。中文请使用完整行政区划（如 "浙江省安吉县"），避免仅用2-3字短名。
         provider: provider 模式，可选 all/qweather/open-meteo/wttr。
 
     Returns:


### PR DESCRIPTION
## Summary

Add disambiguation guidance to `get_weather_by_name` tool description for CJK place names.

## Problem

Short Chinese place names (e.g. "安吉") can be resolved to obscure hamlets instead of well-known cities via the Photon geocoding fallback:

| Query | Photon Result |
|-------|--------------|
| `安吉` | ❌ 安吉, 龙街镇, 云南省 |
| `安吉县` | ✅ 安吉县, 湖州市, 浙江省 |
| `浙江安吉` | ✅ 浙江安吉 |

This happens because Photon matches the literal string "安吉" to a tiny village in Yunnan rather than the county-level city in Zhejiang.

## Solution

Rather than adding complex disambiguation logic in the geocoding layer, add guidance directly in the tool description (which the LLM reads when deciding how to call the tool):

- Guide users to use full administrative names (e.g. "浙江安吉", "杭州西湖区")
- Recommend `get_weather_by_position(lat, lon)` for precise positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)