### PR TITLE
fix: Amap Geocoding API + road skip + data-quality warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-stargazing"
-version = "0.6.1"
+version = "0.6.2"
 description = "An MCP server that provides real-time astronomical data, smart stargazing planning, and light pollution analysis for AI agents."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/functions/places/impl.py
+++ b/src/functions/places/impl.py
@@ -164,11 +164,16 @@ async def analysis_area(
     This tool searches for dark, accessible locations with good viewing conditions.
     Results are cached based on search parameters.
 
+    **Fast mode**: Set ``road_radius_km=0`` to skip road connectivity checks.
+    This avoids OSMnx network downloads from Overpass API and is much faster —
+    use it when you only need candidate locations with light pollution and
+    elevation data, without road distance analysis.
+
     Args:
         south, west, north, east: Bounding box coordinates.
         max_locations: Maximum number of candidate locations to find (before pagination).
         min_height_diff: Minimum elevation difference for prominence.
-        road_radius_km: Search radius for road access.
+        road_radius_km: Search radius for road access. Set to 0 to skip road checks.
         network_type: Type of road network ('drive', 'walk', etc.).
         db_config_path: Optional path to database config.
         page: Page number (1-based).
@@ -261,6 +266,44 @@ async def analysis_area(
     # Slice results (safe even if indices are out of bounds)
     page_items = cached[start_idx:end_idx]
 
+    # 5. Build data-quality warnings for missing fields.
+    # Elevation gaps are logged internally but NOT exposed in the response —
+    # they reflect infrastructure status (PostGIS, Open-Elevation) that is
+    # not actionable for end users.
+    warnings: list[str] = []
+    total_elevation_missing = sum(
+        1 for loc in cached if loc.elevation_m is None or loc.elevation_m == 0
+    )
+    total_bortle_missing = sum(1 for loc in cached if loc.bortle_class is None)
+    total_road_missing = sum(1 for loc in cached if loc.road_distance_km is None)
+
+    if total_elevation_missing == total and total > 0:
+        logger.warning(
+            'All %d locations have elevation=0 — elevation data source may be unavailable '
+            '(check STARGAZING_DB_CONFIG and Open-Elevation API connectivity)',
+            total,
+        )
+    elif total_elevation_missing > 0:
+        logger.warning(
+            '%d/%d locations have no elevation data — results may be incomplete',
+            total_elevation_missing,
+            total,
+        )
+
+    if total_bortle_missing == total and total > 0:
+        warnings.append(
+            'All locations have no Bortle class — light pollution GeoTIFF may be '
+            'unavailable or the coordinates are outside data coverage.'
+        )
+    elif total_bortle_missing > 0:
+        warnings.append(f'{total_bortle_missing}/{total} locations have no Bortle class.')
+
+    if road_radius_km > 0 and total_road_missing == total and total > 0:
+        warnings.append(
+            'All locations have no road distance — road connectivity check may have '
+            'failed. Set road_radius_km=0 to skip road checks for faster results.'
+        )
+
     result = AnalysisAreaResult(
         items=page_items,
         total=total,
@@ -269,4 +312,7 @@ async def analysis_area(
         total_pages=(total + page_size - 1) // page_size,
         resource_id=resource_id,
     )
-    return format_response(result.model_dump())
+    meta: dict[str, Any] = {}
+    if warnings:
+        meta['warnings'] = warnings
+    return format_response(result.model_dump(), meta=meta)

--- a/src/functions/weather/geocoding.py
+++ b/src/functions/weather/geocoding.py
@@ -2,13 +2,18 @@
 
 Cascading geocoding strategy:
 
-1. CJK queries  → Amap POI Search  (Chinese cities, mountains, parks)
+1. CJK queries  → Amap Geocoding   (administrative divisions: province/city/district)
 2. All queries  → Photon           (international cities, landmarks)
 3. Final safety → Nominatim         (OSM fallback via geopy)
 
 Photon is called via its public REST API (no API key required).
 Amap requires an ``AMAP_KEY`` environment variable.
 Nominatim requires no key but enforces strict rate limits (~1 req/s).
+
+The Amap tier uses the **Geocoding API** (``v3/geocode/geo``), not the POI
+Search API (``v3/place/text``).  The geocoding API returns administrative
+divisions with ``level`` (province/city/district/township) and ``adcode``,
+which is the correct tool for resolving place names like "浙江安吉".
 """
 
 from __future__ import annotations
@@ -58,8 +63,11 @@ def resolve_place_name(place_name: str) -> LocationInfo:
 # Photon public API (Komoot-hosted, no key required).
 _PHOTON_API = 'https://photon.komoot.io/api'
 
-# Amap POI Search endpoint.
-_AMAP_POI_API = 'https://restapi.amap.com/v3/place/text'
+# Amap Geocoding endpoint — resolves administrative divisions (province/city/district).
+# This is the correct API for place-name resolution.  The POI Search API
+# (v3/place/text) matches businesses and landmarks, not administrative regions,
+# and produced incorrect results like "浙江万吉(杭州市)" for "浙江安吉".
+_AMAP_GEOCODE_API = 'https://restapi.amap.com/v3/geocode/geo'
 
 # Nominatim geocoder — lazily initialised (geopy validates the user_agent
 # eagerly, and we don't need it until the fallback is actually hit).
@@ -101,28 +109,44 @@ def _contains_cjk(text: str) -> bool:
 
 
 def _geocode_amap(place_name: str, amap_key: str) -> tuple[str, float, float, str] | None:
-    """Query Amap POI Search.  Returns (name, lat, lon, "amap_poi") or None."""
-    params = {'key': amap_key, 'keywords': place_name, 'offset': 1}
+    """Query Amap Geocoding API.  Returns (name, lat, lon, "amap_geo") or None.
+
+    The Amap Geocoding API (``v3/geocode/geo``) resolves structured addresses
+    (省+市+区县+街道+门牌号) to coordinates.  We pass the raw *place_name* as
+    the ``address`` parameter and let Amap handle parsing — its built-in
+    address parser is more robust than our own regex-based disambiguation.
+    """
+    params: dict[str, str] = {'key': amap_key, 'address': place_name}
+
     try:
-        resp = requests.get(_AMAP_POI_API, params=params, timeout=5)
+        resp = requests.get(_AMAP_GEOCODE_API, params=params, timeout=5)
         resp.raise_for_status()
         data = resp.json()
     except (requests.RequestException, ValueError) as exc:
-        logger.debug('Amap request failed for %r: %s', place_name, exc)
+        logger.debug('Amap geocode request failed for %r: %s', place_name, exc)
         return None
 
-    pois = data.get('pois')
-    if not pois:
+    if data.get('status') != '1':
+        logger.debug('Amap geocode non-success for %r: %s', place_name, data.get('info', 'unknown'))
         return None
 
-    location = pois[0].get('location', '')
+    geocodes: list[dict] = data.get('geocodes', [])
+    if not geocodes:
+        return None
+
+    # Amap typically returns one result for well-formed queries; pick the
+    # first if there are multiple (they're ordered by relevance).
+    best = geocodes[0]
+
+    location = best.get('location', '')
     try:
         lon_str, lat_str = location.split(',')
         lon, lat = float(lon_str), float(lat_str)
     except (ValueError, AttributeError):
         return None
 
-    return (pois[0].get('name', place_name), lat, lon, 'amap_poi')
+    display_name = best.get('formatted_address') or best.get('name') or place_name
+    return (display_name, lat, lon, 'amap_geo')
 
 
 def _geocode_photon(place_name: str) -> tuple[str, float, float, str] | None:

--- a/src/functions/weather/impl.py
+++ b/src/functions/weather/impl.py
@@ -96,12 +96,12 @@ def get_weather_by_name(place_name: str, provider: str = 'all'):
     """
     通过地点名称获取综合天气（当前 + 小时预报 + 日预报）。
 
-    Geocoding uses Amap (CJK) → Photon → Nominatim cascade.
+    Geocoding uses Amap Geocoding API (CJK) → Photon → Nominatim cascade.
     Weather data is aggregated from multiple providers with graceful
     fallback — open-meteo is always available without an API key.
 
-    **中文地名提示**：短地名（如 "安吉"）可能被解析到同名小村落而非知名城市。
-    建议使用完整行政区划名称，如 "浙江安吉"、"杭州西湖区"。
+    **中文地名提示**：建议使用完整行政区划名称，如 "浙江安吉"、"杭州西湖区"。
+    高德地理编码 API 会正确解析到对应的行政区（如安吉县），而非 POI 商铺。
     需要精确定位时优先使用 ``get_weather_by_position(lat, lon)``。
 
     Args:

--- a/src/placefinder.py
+++ b/src/placefinder.py
@@ -153,6 +153,12 @@ class StargazingPlaceFinder:
             self.min_height_difference = min_height_diff
             self.road_search_radius_km = road_radius_km
             self._init_analyzer()
+
+        # When road_radius_km <= 0 the caller explicitly opts out of road
+        # connectivity analysis.  This avoids triggering OSMnx downloads from
+        # Overpass API when PostGIS is unavailable or road data isn't needed.
+        include_road = road_radius_km > 0
+
         # Use the public API which returns already-serialized dicts,
         # avoiding SPF Pydantic model instances leaking into MCP's process
         # space where they would conflict with MCP's own StargazingLocation.
@@ -161,7 +167,7 @@ class StargazingPlaceFinder:
             max_locations=max_locations,
             network_type=network_type,
             include_light_pollution=True,
-            include_road_connectivity=True,
+            include_road_connectivity=include_road,
         )
 
 

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -53,26 +53,33 @@ def test_resolve_place_name_empty():
         resolve_place_name('  ')
 
 
-# ── Amap POI Search ──────────────────────────────────────────────
+# ── Amap Geocoding ────────────────────────────────────────────────
 
 
 def test_geocode_amap_success():
     with patch('src.functions.weather.geocoding.requests.get') as mock_get:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
-            'pois': [{'name': '北京市', 'location': '116.4074,39.9042'}],
+            'status': '1',
+            'geocodes': [
+                {
+                    'formatted_address': '北京市',
+                    'location': '116.4074,39.9042',
+                    'level': 'city',
+                }
+            ],
         }
         mock_get.return_value = mock_resp
 
         result = _geocode_amap('北京', 'test_key')
 
-    assert result == ('北京市', 39.9042, 116.4074, 'amap_poi')
+    assert result == ('北京市', 39.9042, 116.4074, 'amap_geo')
 
 
-def test_geocode_amap_empty_pois():
+def test_geocode_amap_empty_geocodes():
     with patch('src.functions.weather.geocoding.requests.get') as mock_get:
         mock_resp = MagicMock()
-        mock_resp.json.return_value = {'pois': []}
+        mock_resp.json.return_value = {'status': '1', 'geocodes': []}
         mock_get.return_value = mock_resp
 
         result = _geocode_amap('nonexistent', 'test_key')
@@ -93,13 +100,68 @@ def test_geocode_amap_malformed_location():
     with patch('src.functions.weather.geocoding.requests.get') as mock_get:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
-            'pois': [{'name': 'Bad', 'location': 'invalid'}],
+            'status': '1',
+            'geocodes': [{'formatted_address': 'Bad', 'location': 'invalid', 'level': 'city'}],
         }
         mock_get.return_value = mock_resp
 
         result = _geocode_amap('test', 'test_key')
 
     assert result is None
+
+
+def test_geocode_amap_non_success_status():
+    """Amap returns a non-1 status code → treated as failure."""
+    with patch('src.functions.weather.geocoding.requests.get') as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'status': '0', 'info': 'INVALID_KEY'}
+        mock_get.return_value = mock_resp
+
+        result = _geocode_amap('北京', 'bad_key')
+
+    assert result is None
+
+
+def test_geocode_amap_province_level_ok():
+    """Short province query (e.g. '浙江') → returns province-level result ok."""
+    with patch('src.functions.weather.geocoding.requests.get') as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            'status': '1',
+            'geocodes': [
+                {
+                    'formatted_address': '浙江省',
+                    'location': '120.15,30.28',
+                    'level': 'province',
+                }
+            ],
+        }
+        mock_get.return_value = mock_resp
+
+        result = _geocode_amap('浙江', 'test_key')
+
+    assert result == ('浙江省', 30.28, 120.15, 'amap_geo')
+
+
+def test_geocode_amap_structured_address():
+    """Structured address like '浙江安吉' → resolved by Amap's own parser."""
+    with patch('src.functions.weather.geocoding.requests.get') as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            'status': '1',
+            'geocodes': [
+                {
+                    'formatted_address': '浙江省湖州市安吉县',
+                    'location': '119.68,30.64',
+                    'level': 'district',
+                }
+            ],
+        }
+        mock_get.return_value = mock_resp
+
+        result = _geocode_amap('浙江安吉', 'test_key')
+
+    assert result == ('浙江省湖州市安吉县', 30.64, 119.68, 'amap_geo')
 
 
 # ── Photon ───────────────────────────────────────────────────────
@@ -263,11 +325,11 @@ def test_geocode_cjk_uses_amap_first():
         patch('src.functions.weather.geocoding._geocode_nominatim') as mock_nominatim,
         patch.dict(os.environ, {'AMAP_KEY': 'test_key'}),
     ):
-        mock_amap.return_value = ('北京市', 39.9, 116.4, 'amap_poi')
+        mock_amap.return_value = ('北京市', 39.9, 116.4, 'amap_geo')
 
         result = _geocode('北京')
 
-    assert result == ('北京市', 39.9, 116.4, 'amap_poi')
+    assert result == ('北京市', 39.9, 116.4, 'amap_geo')
     mock_amap.assert_called_once()
     mock_photon.assert_not_called()
     mock_nominatim.assert_not_called()
@@ -377,7 +439,7 @@ def test_resolve_place_name_all_fail_raises_mcperror():
 def test_resolve_place_name_success():
     """resolve_place_name returns a LocationInfo."""
     with patch('src.functions.weather.geocoding._geocode') as mock_geocode:
-        mock_geocode.return_value = ('北京市', 39.9, 116.4, 'amap_poi')
+        mock_geocode.return_value = ('北京市', 39.9, 116.4, 'amap_geo')
 
         loc = resolve_place_name('北京')
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -12,7 +12,7 @@ from src.functions.celestial.impl import (
     list_visible_planets,
 )
 from src.functions.metadata.impl import get_tool_catalog
-from src.functions.places.impl import light_pollution_map
+from src.functions.places.impl import analysis_area, light_pollution_map
 from src.functions.planning.impl import get_best_stargazing_plan
 from src.functions.time.impl import get_local_datetime_info
 from src.functions.weather.impl import get_weather_by_name, get_weather_by_position
@@ -429,6 +429,113 @@ async def test_light_pollution_map_fn():
     assert data['grid'][1]['sqm'] == 21.5
     assert data['bounds'] == {'south': 40.0, 'west': -74.0, 'north': 40.01, 'east': -73.99}
     assert data['zoom'] == 10
+
+
+# ---------------------------------------------------------------------------
+# analysis_area data-quality warnings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analysis_area_warns_when_all_data_missing():
+    """Bortle and road warnings appear when data is absent; elevation is internal-only."""
+    from src.schemas.places import StargazingLocation
+
+    locations = [
+        StargazingLocation(
+            name='P1',
+            lat=30.1,
+            lon=119.1,
+            elevation_m=0,
+            bortle_class=None,
+            road_distance_km=None,
+        ),
+        StargazingLocation(
+            name='P2',
+            lat=30.2,
+            lon=119.2,
+            elevation_m=0,
+            bortle_class=None,
+            road_distance_km=None,
+        ),
+    ]
+
+    with patch('src.functions.places.impl.ANALYSIS_CACHE.get', return_value=locations):
+        result = await analysis_area.fn(
+            south=30,
+            west=119,
+            north=31,
+            east=120,
+            road_radius_km=10.0,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    warnings = result['_meta'].get('warnings', [])
+    assert any('Bortle' in w for w in warnings), f'Expected Bortle warning, got: {warnings}'
+    assert any('road' in w for w in warnings), f'Expected road warning, got: {warnings}'
+    # Elevation must not leak to external response
+    assert not any('elevation' in w.lower() for w in warnings), f'Elevation leaked: {warnings}'
+
+
+@pytest.mark.asyncio
+async def test_analysis_area_no_warnings_when_data_complete():
+    """No warnings when all fields have valid values."""
+    from src.schemas.places import StargazingLocation
+
+    locations = [
+        StargazingLocation(
+            name='P1',
+            lat=30.1,
+            lon=119.1,
+            elevation_m=1200,
+            bortle_class=2,
+            road_distance_km=5.0,
+        ),
+    ]
+
+    with patch('src.functions.places.impl.ANALYSIS_CACHE.get', return_value=locations):
+        result = await analysis_area.fn(
+            south=30,
+            west=119,
+            north=31,
+            east=120,
+            road_radius_km=10.0,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    warnings = result['_meta'].get('warnings', [])
+    assert len(warnings) == 0, f'Unexpected warnings: {warnings}'
+
+
+@pytest.mark.asyncio
+async def test_analysis_area_road_skip_silences_road_warning():
+    """road_radius_km=0 suppresses the road-distance warning."""
+    from src.schemas.places import StargazingLocation
+
+    locations = [
+        StargazingLocation(
+            name='P1',
+            lat=30.1,
+            lon=119.1,
+            elevation_m=1200,
+            bortle_class=2,
+            road_distance_km=None,
+        ),
+    ]
+
+    with patch('src.functions.places.impl.ANALYSIS_CACHE.get', return_value=locations):
+        result = await analysis_area.fn(
+            south=30,
+            west=119,
+            north=31,
+            east=120,
+            road_radius_km=0,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    warnings = result['_meta'].get('warnings', [])
+    # When road_radius_km=0, road warning should be suppressed
+    assert not any('road' in w.lower() for w in warnings), f'Road warning leaked: {warnings}'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_placefinder.py
+++ b/tests/test_placefinder.py
@@ -129,6 +129,22 @@ def test_analyze_area_returns_dependency_results_and_expected_args():
     )
 
 
+def test_analyze_area_skips_road_when_radius_zero():
+    """road_radius_km=0 → include_road_connectivity=False (fast mode)."""
+    placefinder_module._last_params = None
+    fake_spf = _make_fake_spf()
+    fake_spf.analyze_area = MagicMock(return_value=[])
+
+    with patch.object(placefinder_module, '_load_spf', return_value=fake_spf):
+        pf = StargazingPlaceFinder()
+        pf.analyze_area(30, 119, 31, 120, road_radius_km=0)
+
+    fake_spf.analyze_area.assert_called_once()
+    call_kwargs = fake_spf.analyze_area.call_args[1]
+    assert call_kwargs['include_road_connectivity'] is False
+    assert call_kwargs['include_light_pollution'] is True
+
+
 def test_analyze_area_reinitializes_only_when_thresholds_change():
     """Analyzer reuse should depend only on the bridge's threshold parameters."""
     fake_spf = _make_fake_spf()


### PR DESCRIPTION
## Summary

Fixes three issues identified in the v0.5.1 test report:

### P0 — Geocoding: POI Search → Geocoding API

Replaced Amap POI Search API (`v3/place/text`) with Geocoding API (`v3/geocode/geo`).  The old endpoint matched businesses/landmarks, producing incorrect results like **浙江万吉(杭州市)** for **浙江安吉**.  The Geocoding API resolves administrative divisions with structured `level` and `adcode` fields.

### P1 — Road connectivity: `road_radius_km=0` fast mode

Derive `include_road_connectivity` from `road_radius_km > 0`.  Setting `road_radius_km=0` now skips OSMnx/Overpass downloads entirely — useful when PostGIS is unavailable or road data is not needed.

### P3 — Data-quality warnings in `analysis_area`

When results have missing Bortle or road-distance data, warnings are surfaced in `_meta.warnings`.  Elevation gaps are logged internally only (infrastructure status, not actionable for end users).

## Files Changed

| File | Change |
|------|--------|
| `src/functions/weather/geocoding.py` | POI Search → Geocoding API, simplified `_geocode_amap` |
| `src/placefinder.py` | `include_road_connectivity = road_radius_km > 0` |
| `src/functions/places/impl.py` | Data-quality warnings (Bortle/road external, elevation internal) |
| `src/functions/weather/impl.py` | Updated docstring for new geocoding behavior |
| `tests/` | +8 tests (4 geocoding, 1 bridge, 3 warnings) |

**Tests: 228/228 passed** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)