### PR TITLE
feat: handle moon phase data from updated core match_telescope_targets

### DIFF
--- a/src/functions/telescope/impl.py
+++ b/src/functions/telescope/impl.py
@@ -137,8 +137,9 @@ async def _get_telescope_targets(
 
     return format_response(
         {
-            'targets': results,
+            'targets': results['targets'],
+            'moon': results['moon'],
             'config': config.model_dump(exclude_none=True),
-            'total': len(results),
+            'total': len(results['targets']),
         }
     )


### PR DESCRIPTION
## Summary

适配 stargazing-core#8 的新返回结构——`match_telescope_targets` 现在返回 dict（含 `targets` 和 `moon` 键），而不是 list。

### Changes

- `get_telescope_targets` 提取 `results['targets']` 和 `results['moon']`
- moon 数据透传至 API 响应

### 依赖

⚠️ 依赖 [stargazing-core#8](https://github.com/StarGazer1995/stargazing-core/pull/8) 先合并

🤖 Generated with [Claude Code](https://claude.com/claude-code)