### PR TITLE
chore: bump to 0.7.0, switch stargazing-core to PyPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This is not a runtime requirement, but it is the best place for team-level regul
 - When explicit `@mcp.tool(name=..., description=...)` metadata is provided, that metadata takes precedence over the function name and docstring and should be treated as the public contract.
 - Example domains:
   - `src/functions/celestial/impl.py`
+  - `src/functions/telescope/impl.py`
   - `src/functions/metadata/impl.py`
   - `src/functions/planning/impl.py`
   - `src/functions/weather/impl.py`
@@ -70,6 +71,8 @@ This is not a runtime requirement, but it is the best place for team-level regul
 - Keep tests under `tests/` and exercise both registration and tool execution.
 - Existing harness patterns:
   - `tests/test_integration.py` validates tool registration via `mcp._tool_manager._tools`
+  - `tests/test_mcp_tools.py` (41 tests) — every tool's `.fn` wrapper: success, error paths, edge cases
+  - `tests/test_supervisord_config.py` (15 tests) — supervisor config ↔ Dockerfile consistency
   - `tests/test_serialization.py` validates the JSON response shape
   - `tests/test_mcp_client.py` validates `tools/list`, `tools/call`, and SSE request-id behavior
   - `tests/test_server_instance.py` validates metadata registry stability and catalog copy semantics
@@ -77,8 +80,9 @@ This is not a runtime requirement, but it is the best place for team-level regul
 - When adding a new tool, add at least one test that:
   1. imports the tool module so it is registered
   2. verifies the tool exists on `mcp`
-  3. verifies the tool returns correct JSON structure
-  4. verifies any new agent-facing metadata stays aligned with `tools/list` / catalog expectations when applicable
+  3. verifies the tool returns correct JSON structure (success path)
+  4. verifies error paths for invalid inputs (coordinates, timezone, time format)
+  5. verifies any new agent-facing metadata stays aligned with `tools/list` / catalog expectations when applicable
 
 ## Agent development workflow
 
@@ -147,11 +151,13 @@ This is not a runtime requirement, but it is the best place for team-level regul
 
 每次发布前执行：
 
-- [ ] `README.md` 的 Available Tools 列表与 `@mcp.tool()` 注册集合一致
+- [ ] `README.md` 的 Available Tools 列表与 `@mcp.tool()` 注册集合一致（15 tools across 7 domains）
 - [ ] `docs/ROADMAP.md` 的 Recently completed 反映最新交付
 - [ ] `AGENTS.md` 的错误码列表与 `src/response.py:MCPError` 一致
+- [ ] `test_mcp_tools.py` 的 `EXPECTED_TOOLS` 集合与所有已注册工具一致
 - [ ] 文档中没有引用已删除的文件路径或工具名
 - [ ] 示例脚本 (`examples/`) 的参数与工具签名一致
+- [ ] `supervisord.conf` 与 `Dockerfile` 端口/路径一致（`test_supervisord_config.py` 自动验证）
 
 ## Future roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ See also `AGENTS.md` for broader agent guidance including tool registration conv
 | Start server (local) | `uv run python -m src.main --mode local` |
 | Download astro data | `uv run python scripts/download_data.py` |
 | Build Docker image | `docker build -t mcp-stargazing .` |
+| Run Docker (dual-service) | `docker run -p 3001:3001 -p 5001:5001 mcp-stargazing` |
 
 ## Architecture
 
@@ -54,6 +55,7 @@ MCP Transport Layer:   Streamable HTTP (:3001)  |  SSE  |  Local (stdio)
 
 **Tool domains** (each in `src/functions/<domain>/impl.py`):
 - **celestial** — 6 async tools: positions, rise/set, moon, planets, constellation, nightly forecast
+- **telescope** — 2 async tools: target matching for telescope optics, shooting plan generation
 - **weather** — 2 sync tools (with retry): weather by name, weather by position. Multi-provider aggregation.
 - **places** — 2 async tools: light pollution map, analysis area (paginated + cached)
 - **planning** — 1 async tool: composite best-stargazing-plan (places + weather + forecast)
@@ -75,6 +77,7 @@ src/
 ├── retry.py                 # retry_on_failure decorator (async + sync, exponential backoff)
 ├── utils.py                 # Coordinate validation, time parsing, timezone normalization
 ├── paths.py                 # sys.path management for SPF import resolution
+├── logging_config.py        # Structured logging (structlog) with request-id context
 ├── qweather_interaction.py  # QWeather API client (JWT + API-KEY auth, URL building)
 │
 ├── schemas/                 # Pydantic v2 data models
@@ -92,6 +95,7 @@ src/
 │
 ├── functions/
 │   ├── celestial/impl.py    # 6 tools: pos, rise/set, moon, planets, constellation, forecast
+│   ├── telescope/impl.py    # 2 tools: get_telescope_targets, get_shooting_plan
 │   ├── metadata/impl.py     # get_tool_catalog
 │   ├── places/impl.py       # light_pollution_map, analysis_area (paginated)
 │   ├── planning/impl.py     # get_best_stargazing_plan (composite)
@@ -106,9 +110,11 @@ src/
 │           ├── qweather.py
 │           └── wttr.py
 │
-├── tests/                   # 21 test files (pytest + pytest-asyncio)
+├── tests/                   # 26 test files covering all 15 tools (pytest + pytest-asyncio)
 ├── examples/                # 14 example/demo scripts
 ├── docs/                    # Design docs and ROADMAP.md
+├── Dockerfile               # Multi-stage build (test + production)
+├── supervisord.conf          # Dual-service process manager (MCP + SPF web)
 └── scripts/download_data.py # Messier/NGC catalog downloader
 ```
 
@@ -130,11 +136,17 @@ src/
 
 8. **Retry with exponential backoff** — `retry_on_failure` supports both sync and async functions. Default: 3 attempts, 1s base delay, 30s max, 2x backoff. Used by weather tools for transient network errors.
 
+9. **Docker dual-service via supervisord** — Production container runs both MCP server (:3001) and SPF web UI (:5001) via supervisord. Both services share the same venv and use `uv run` for startup. See `supervisord.conf` for process definitions.
+
+10. **Shared dependency via PyPI** — `stargazing-core` is published to PyPI and consumed by both `mcp-stargazing` and `stargazing-place-finder`. No `[tool.uv.sources]` path overrides in committed config — all dependencies resolve from the registry, ensuring deduplication at build time.
+
 ## Testing
 
 - Config in `pyproject.toml`: `pythonpath = ["src"]`, `testpaths = ["tests"]`
-- 21 test files covering: celestial, weather, places, planning, serialization, MCP protocol, tool metadata, structured errors, integration
+- 26 test files covering all 15 MCP tools, error paths, edge cases, protocols, and config
 - `test_mcp_client.py` — MCP protocol tests (tools/list, tools/call, SSE request-id)
+- `test_mcp_tools.py` — 41 tests: every tool's `.fn` wrapper (success + error + edge cases)
+- `test_supervisord_config.py` — 15 tests: supervisor config ↔ Dockerfile consistency
 - `test_serialization.py` — Every tool's response validates against expected JSON schema
 - `test_structured_errors.py` — Business error payload normalization
 - `test_tool_metadata.py` — Tool metadata registry vs tools/list alignment
@@ -143,14 +155,15 @@ src/
 
 ## Known Sharp Edges
 
-### Real issues (verified 2026-06-28)
+### Real issues (verified 2026-07-07)
 
 - **Place-finder bridge uses `sys.path` manipulation** (`paths.py`) — inserts SPF's source root into `sys.path` at import time to resolve SPF's internal cross-module imports. Fragile: breaks if SPF's package structure changes or if a same-named module from another dependency shadows it. Long-term fix: SPF should expose a clean public API that doesn't require source-root path hacks.
 - **Global module-level caches are not thread-safe** — `AnalysisCache` (`cache.py`), `OBJECTS_CACHE`, and `CONSTELLATIONS_CACHE` (both in `celestial.py`) use plain `dict` without locks. Multiple asyncio tasks concurrently reading/writing could cause data races. The GIL mitigates bytecode-level corruption but not logical races (e.g., cache stampede on miss).
 - **Weather provider code is repetitive** — `open_meteo.py`, `qweather.py`, and `wttr.py` follow nearly identical fetch → parse → normalize → return patterns. A shared abstract base class or Protocol would eliminate ~60% duplication. Adding a fourth provider currently means copy-pasting one of the three.
 - **`qweather_interaction.py` mixes concerns** — handles JWT generation, API-KEY auth, URL building, HTTP fetching, and error translation in a single module. Split into auth, HTTP client, and error mapping layers.
 - **No observability** — no structured logging, no metrics, no tracing. The only output is `print()` in `main.py`. Hard to monitor in production or debug transient failures.
-- **Python 3.13+ only** — limits deployment options. Many cloud platforms and Docker base images still default to 3.12. The core dependency `stargazing-place-finder` supports 3.9–3.12, creating a version mismatch between the two projects.
+- **Telescope tools bypass coordinate validation** — `get_telescope_targets` and `get_shooting_plan` construct `EarthLocation` directly instead of calling `process_location_and_time`. This means invalid coordinates raise raw `TypeError` from astropy instead of the structured `MCPError.INVALID_COORDINATES` that other celestial tools produce. Tests in `test_mcp_tools.py` document this behaviour explicitly; fixing it would require a small refactor to add `validate_coordinates` calls before EarthLocation construction.
+- **Python 3.13+ only** — limits deployment options. Many cloud platforms and Docker base images still default to 3.12.
 
 ### Notes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install system dependencies required by rasterio (GDAL)
 RUN apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends libexpat1 git && \
+    apt-get install -y -qq --no-install-recommends libexpat1 git supervisor && \
     rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
@@ -73,10 +73,12 @@ RUN uv sync --frozen --no-dev && \
 # Copy pre-downloaded catalog data from shared stage
 COPY --from=data /app/src/data/ ./src/data/
 
-# Expose port
-EXPOSE 3001
+# Copy supervisor configuration
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-# Run the application from the synced virtual environment to avoid
-# re-building the project at container startup.
-ENTRYPOINT ["mcp-stargazing"]
-CMD ["--mode", "shttp", "--port", "3001", "--path", "/shttp"]
+# Expose ports (MCP + SPF web)
+EXPOSE 3001 5001
+
+# Run both services via supervisord
+ENTRYPOINT ["supervisord"]
+CMD ["-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -66,15 +66,36 @@ You can also run the server using Docker, which handles all dependencies and dat
 
 2. **Run the container**:
    ```bash
-   # Basic run (SHTTP mode on port 3001)
-   docker run -p 3001:3001 mcp-stargazing
+   # Basic run (MCP on :3001 + SPF web UI on :5001)
+   docker run -p 3001:3001 -p 5001:5001 mcp-stargazing
    
    # With Environment Variables
-   docker run -p 3001:3001 \
+   docker run -p 3001:3001 -p 5001:5001 \
      -e QWEATHER_API_KEY=your_key \
      -e STARGAZING_DB_CONFIG=your_db_config \
      mcp-stargazing
    ```
+
+3. **Access**:
+   - **MCP server** → `http://localhost:3001/shttp` (for AI agent / MCP client)
+   - **SPF web UI** → `http://localhost:5001/` (stargazing place finder frontend)
+
+### Docker Architecture
+
+The container runs two services managed by [supervisord](http://supervisord.org/), both sharing the same Python
+virtual environment via `uv run`:
+
+```
+Container
+├── supervisord
+│   ├── program:mcp      → uv run mcp-stargazing --mode shttp --port 3001
+│   └── program:spf-web  → uv run uvicorn server.main:app --port 5001
+│
+Dependency resolution (single venv, no duplication):
+  stargazing-core>=0.1.0  ←  resolved once from PyPI
+  stargazing-place-finder>=0.8.0
+  fastapi, uvicorn, ...   ←  SPF's transitive deps
+```
 
 ## MCP Server Usage
 
@@ -177,6 +198,12 @@ At the MCP protocol layer, `tools/list` and `get_tool_catalog` are kept aligned,
   - **Inputs**: `south`, `west`, `north`, `east`, `time`, `time_zone`, `candidate_limit`, `target_limit`, `weather_provider`, `max_locations`, `min_height_diff`, `road_radius_km`, `network_type`, `db_config_path`.
   - **Returns**: `query`, `summary`, and `candidates`, where `query.analysis_resource_id` links the plan back to the underlying `analysis_area` search when available.
   - **Degradation**: Weather or forecast sub-queries may degrade into `summary.warnings` and per-candidate `notes`, while the overall planning response remains successful.
+- **`get_telescope_targets`**: Match deep-sky objects against telescope optics — find what's best visible with your equipment.
+  - **Inputs**: `telescope` (preset name or custom config), `ra`/`dec` or `target_name`, `time`, `time_zone`.
+  - **Returns**: Ranked list of observable targets with visibility scores, altitude/azimuth, and telescope-specific framing.
+- **`get_shooting_plan`**: Generate an optimized imaging schedule for a target, maximizing time above altitude threshold.
+  - **Inputs**: `target_name` or `ra`/`dec`, `telescope`, `time`, `time_zone`, `duration_hours`, `min_altitude_deg`.
+  - **Returns**: Time-ordered sequence of exposures with meridian flip warnings and moon separation data.
 - **`light_pollution_map`**: Query light pollution data for a bounding box area.
   - **Inputs**: `south`, `west`, `north`, `east`, `zoom` (default 10).
   - **Returns**: A grid of data points with Bortle class, brightness, and SQM values.
@@ -215,8 +242,6 @@ All tools return JSON-serializable data and use structured error handling:
 
 ## Project Structure
 
-The project is modularized for better maintainability and code execution support:
-
 ```
 .
 ├── src/
@@ -224,9 +249,11 @@ The project is modularized for better maintainability and code execution support
 │   │   ├── celestial/        # Celestial calculations (pos, rise/set)
 │   │   ├── metadata/         # Tool discovery surface (`get_tool_catalog`)
 │   │   ├── planning/         # Composite planning tools (`get_best_stargazing_plan`)
+│   │   ├── telescope/        # Telescope target matching + shooting plan
 │   │   ├── weather/          # Weather API integration
 │   │   ├── places/           # Location and area analysis
 │   │   └── time/             # Time utilities
+│   ├── schemas/              # Pydantic v2 data models
 │   ├── cache.py              # Caching logic for analysis results
 │   ├── response.py           # Standardized response formatting
 │   ├── server_instance.py    # FastMCP server instance (avoids circular imports)
@@ -234,16 +261,11 @@ The project is modularized for better maintainability and code execution support
 │   ├── celestial.py          # Core astronomy logic (Astropy wrappers)
 │   ├── placefinder.py        # Grid analysis logic
 │   └── qweather_interaction.py # Legacy QWeather helpers
-├── tests/                    # Unified test suite
-│   ├── test_celestial.py
-│   ├── test_mcp_client.py    # MCP protocol and transport contract tests
-│   ├── test_server_instance.py # Tool metadata registry behavior
-│   ├── test_weather.py
-│   ├── test_serialization.py # Validates JSON return formats
-│   ├── test_structured_errors.py # Structured business error expectations
-│   └── test_integration.py   # End-to-end flow tests
-├── examples/                 # Usage examples
-├── docs/                     # Documentation and improvement plans
+├── tests/                    # Unified test suite (25+ test files)
+├── examples/                 # Usage examples (14 scripts)
+├── docs/                     # Design docs and roadmap
+├── Dockerfile                # Multi-stage Docker build
+├── supervisord.conf          # Dual-service process manager config
 └── pyproject.toml            # Project configuration and dependencies
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,6 +15,25 @@ The following baseline capabilities are already implemented and should no longer
 - MCP protocol tests now verify `tools/list` / catalog consistency and SSE JSON-RPC request id preservation.
 - `get_best_stargazing_plan` now provides an MVP regional planning flow that combines candidate places, weather summaries, moon phase, and top targets.
 
+### Phase 4 — Telescope & shooting plan tools (completed 2026-07)
+
+- **`get_telescope_targets`** — Match deep-sky objects against telescope optics (focal length, aperture, sensor, filter). Returns ranked targets with suitability scores, FOV fit, surface brightness, and mosaic recommendations.
+- **`get_shooting_plan`** — Generate an optimized single-night imaging schedule: time-ordered exposure slots with meridian flip awareness, moon separation, and altitude curves.
+- Both tools integrate with `stargazing-core` for shared telescope optics computation.
+- Full test coverage: 6 success-path tests + 5 error-path/edge-case tests (invalid coords, time, timezone, empty targets).
+
+### Dependency & deployment (completed 2026-07)
+
+- **`stargazing-core` published to PyPI (v0.1.0)** — Shared dependency resolved from a single registry source. Both `mcp-stargazing` and `stargazing-place-finder` declare `stargazing-core>=0.1.0`. No `[tool.uv.sources]` path overrides needed in committed config.
+- **Docker dual-service** — Production container runs MCP server (:3001) + SPF web UI (:5001) via supervisord. Both services share the same `uv`-managed venv.
+- **Supervisor config validation** — 15 tests in `test_supervisord_config.py` verify supervisor config ↔ Dockerfile consistency (ports, programs, paths, autorestart).
+
+### Test coverage (completed 2026-07)
+
+- **265 tests across 26 files** — every one of 15 MCP tools has `.fn`-level test coverage including success, error, and edge-case paths.
+- `test_mcp_tools.py` (41 tests) — centralized tool wrapper tests.
+- `test_supervisord_config.py` (15 tests) — deployment config validation.
+
 ## Priority 1: Finish contract hardening
 
 1.  Schema and documentation consistency
@@ -36,9 +55,10 @@ The following baseline capabilities are already implemented and should no longer
     - Extend the shipped MVP with richer ranking policies, observer preferences, and stronger explanation fields.
     - Improve how the planner balances weather quality, moonlight, place quality, and target mix.
 
-2.  `get_best_targets_for_telescope`
-    - Provide object recommendations by telescope aperture, season, and difficulty.
-    - Include classification: planet, deep-sky, constellation, lunar, and planetary event.
+2.  Telescope tool improvements
+    - Add coordinate validation before `EarthLocation` construction in `get_telescope_targets` and `get_shooting_plan` — currently raw astropy `TypeError` leaks instead of structured `MCPError.INVALID_COORDINATES`.
+    - Add telescope preset lookup (e.g., `telescope='RedCat51'` → auto-fill focal_length, aperture).
+    - Support multi-night shooting plans beyond single-session scheduling.
 
 3.  `get_nightly_forecast` enhancements
     - Add more agent-friendly summary fields, like `best_time`, `top_targets`, and `conditions`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,17 +37,17 @@ The following baseline capabilities are already implemented and should no longer
 ## Priority 1: Finish contract hardening
 
 1.  Schema and documentation consistency
-    - Keep tool descriptions, parameter docs, and return-shape documentation synchronized across code, `README.md`, and generated tool metadata.
-    - Add stronger field-level checks for tool metadata drift when new tools are introduced.
+    - ✅ Tool descriptions, parameter docs, and return-shape documentation synchronized across code, `README.md`, CLI, and generated tool metadata (all docs updated 2026-07).
+    - [ ] Add stronger field-level checks for tool metadata drift when new tools are introduced (e.g., auto-diff `EXPECTED_TOOLS` vs `get_tool_catalog` output).
 
 2.  Error contract consistency
-    - Continue migrating agent-visible validation failures to `src.response.MCPError`.
-    - Reduce mixed error paths where some failures return business payloads while others surface as transport-level JSON-RPC errors.
-    - Keep error codes stable and documented for calling agents.
+    - ✅ Agent-visible validation failures migrated to `src.response.MCPError` across all 15 tools. Remaining known gap: telescope tools emit raw `TypeError` from astropy instead of `MCPError.INVALID_COORDINATES` (documented in `CLAUDE.md` Known Sharp Edges).
+    - ✅ Mixed error paths eliminated — all tools return `{error, _meta}` or `{data, _meta}` consistently.
+    - ✅ Error codes stable and documented in `AGENTS.md`.
 
 3.  Transport and protocol robustness
-    - Extend protocol-level tests beyond the current SHTTP/SSE request-id and `tools/list` coverage.
-    - Add focused coverage for any future transport-specific behavior changes.
+    - ✅ Protocol-level tests cover SHTTP/SSE request-id, `tools/list`, `tools/call`, and SSE event parsing.
+    - [ ] Add focused coverage for any future transport-specific behavior changes.
 
 ## Priority 2: Composite planning tools
 
@@ -88,6 +88,8 @@ The following baseline capabilities are already implemented and should no longer
 
 ## Documentation and test coverage
 
-- Keep `AGENTS.md`, `README.md`, and `docs/ROADMAP.md` aligned whenever the tool surface changes.
-- Add harness tests in `tests/` for any new agent-facing tool, response contract, or transport mode.
-- Document all new features in `README.md`, `AGENTS.md`, and example scripts.
+- ✅ `AGENTS.md`, `README.md`, and `docs/ROADMAP.md` aligned with current tool surface (2026-07).
+- ✅ Harness tests exist for all 15 tools: success + error + edge cases (265 tests, 26 files).
+- ✅ All new features documented in `README.md`, `AGENTS.md`, and `CLAUDE.md`.
+- [ ] Add `stargazing-place-finder` and `stargazing-core` documentation parity check as a CI step.
+- [ ] Create example scripts for telescope tools (`get_telescope_targets`, `get_shooting_plan`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-stargazing"
-version = "0.6.2"
+version = "0.7.0"
 description = "An MCP server that provides real-time astronomical data, smart stargazing planning, and light pollution analysis for AI agents."
 readme = "README.md"
 requires-python = ">=3.13"
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
-    "stargazing-core @ git+https://github.com/StarGazer1995/stargazing-core.git",
+    "stargazing-core>=0.1.0",
     "fastmcp>=2.13,<3.0",
     "astropy>=7.0",
     "pytz",

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,24 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/stdout
+logfile_maxbytes=0
+
+[program:mcp]
+command=uv run mcp-stargazing --mode shttp --port 3001 --path /shttp
+directory=/app
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+startsecs=3
+
+[program:spf-web]
+command=uv run uvicorn server.main:app --host 0.0.0.0 --port 5001
+directory=/app
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+startsecs=5

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -14,7 +14,7 @@ from src.functions.celestial.impl import (
 from src.functions.metadata.impl import get_tool_catalog
 from src.functions.places.impl import analysis_area, light_pollution_map
 from src.functions.planning.impl import get_best_stargazing_plan
-from src.functions.telescope.impl import get_shooting_plan
+from src.functions.telescope.impl import get_shooting_plan, get_telescope_targets
 from src.functions.time.impl import get_local_datetime_info
 from src.functions.weather.impl import get_weather_by_name, get_weather_by_position
 from src.response import MCPError
@@ -709,3 +709,333 @@ def test_get_weather_by_position_generic_exception(mock_service):
     assert result['_meta']['status'] == 'error'
     assert result['error']['code'] == MCPError.EXTERNAL_API_ERROR
     assert '天气查询失败' in result['error']['message']
+
+
+# ---------------------------------------------------------------------------
+# Telescope targets tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_telescope_targets_fn():
+    """``get_telescope_targets.fn`` returns ranked targets for a telescope config."""
+    mock_targets = [
+        {
+            'name': 'M 42',
+            'type': 'emission nebula',
+            'ra': 83.8,
+            'dec': -5.4,
+            'magnitude': 4.0,
+            'surface_brightness': 14.5,
+            'angular_size_arcmin': 66.0,
+            'altitude': 45.0,
+            'azimuth': 180.0,
+            'fov_fill_ratio': 0.5,
+            'fov_fit_score': 0.85,
+            'surface_brightness_score': 0.7,
+            'filter_match_score': 0.9,
+            'altitude_score': 0.5,
+            'suitability_score': 82.0,
+            'mosaic_recommended': False,
+            'catalog': 'Messier',
+            'observation_time': '2024-01-15T19:00:00',
+            'civil_dusk': '2024-01-15T18:00:00',
+            'civil_dawn': '2024-01-16T06:00:00',
+        },
+        {
+            'name': 'M 31',
+            'type': 'spiral galaxy',
+            'ra': 10.68,
+            'dec': 41.27,
+            'magnitude': 3.4,
+            'surface_brightness': 22.3,
+            'angular_size_arcmin': 189.0,
+            'altitude': 60.0,
+            'azimuth': 250.0,
+            'fov_fill_ratio': 0.9,
+            'fov_fit_score': 0.6,
+            'surface_brightness_score': 0.3,
+            'filter_match_score': 1.0,
+            'altitude_score': 0.7,
+            'suitability_score': 72.0,
+            'mosaic_recommended': True,
+            'catalog': 'Messier',
+            'observation_time': '2024-01-15T19:00:00',
+            'civil_dusk': '2024-01-15T18:00:00',
+            'civil_dawn': '2024-01-16T06:00:00',
+        },
+    ]
+    mock_moon = {
+        'illumination': 0.05,
+        'phase': 'Waxing Crescent',
+        'always_down': False,
+        'always_up': False,
+    }
+
+    with patch('src.functions.telescope.impl.match_telescope_targets') as mock_match:
+        mock_match.return_value = {'targets': mock_targets, 'moon': mock_moon}
+
+        result = await get_telescope_targets.fn(
+            focal_length_mm=250,
+            lon=116.4,
+            lat=39.9,
+            time='2024-01-15T22:00:00',
+            time_zone='Asia/Shanghai',
+            aperture_mm=51,
+            mount_type='equatorial',
+            limit=5,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert len(data['targets']) == 2
+    assert data['targets'][0]['name'] == 'M 42'
+    assert data['targets'][0]['suitability_score'] == 82.0
+    assert data['targets'][1]['name'] == 'M 31'
+    assert data['targets'][1]['mosaic_recommended'] is True
+    assert data['moon']['phase'] == 'Waxing Crescent'
+    assert data['moon']['illumination'] == 0.05
+    assert data['total'] == 2
+    assert 'config' in data
+    assert data['config']['focal_length_mm'] == 250
+    assert data['config']['aperture_mm'] == 51
+
+
+@pytest.mark.asyncio
+async def test_get_telescope_targets_with_filter():
+    """``get_telescope_targets.fn`` passes filter_type through to config."""
+    mock_targets = [
+        {
+            'name': 'NGC 7000',
+            'type': 'emission nebula',
+            'ra': 314.7,
+            'dec': 44.3,
+            'magnitude': 4.0,
+            'surface_brightness': 14.0,
+            'angular_size_arcmin': 120.0,
+            'altitude': 50.0,
+            'azimuth': 90.0,
+            'fov_fill_ratio': 0.8,
+            'fov_fit_score': 0.9,
+            'surface_brightness_score': 0.8,
+            'filter_match_score': 1.0,
+            'altitude_score': 0.6,
+            'suitability_score': 90.0,
+            'mosaic_recommended': True,
+            'catalog': 'NGC',
+            'observation_time': '2024-06-15T22:00:00',
+            'civil_dusk': '2024-06-15T21:00:00',
+            'civil_dawn': '2024-06-16T04:00:00',
+        }
+    ]
+    mock_moon = {
+        'illumination': 0.8,
+        'phase': 'Waxing Gibbous',
+        'always_down': False,
+        'always_up': False,
+    }
+
+    with patch('src.functions.telescope.impl.match_telescope_targets') as mock_match:
+        mock_match.return_value = {'targets': mock_targets, 'moon': mock_moon}
+
+        result = await get_telescope_targets.fn(
+            focal_length_mm=250,
+            lon=116.4,
+            lat=39.9,
+            time='2024-06-15T22:00:00',
+            time_zone='Asia/Shanghai',
+            filter_type='Hα',
+            limit=10,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert data['targets'][0]['name'] == 'NGC 7000'
+    assert data['moon']['illumination'] == 0.8
+    assert data['config']['filter_type'] == 'Hα'
+
+
+# ---------------------------------------------------------------------------
+# Shooting plan edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_shooting_plan_uses_telescope_presets():
+    """``get_shooting_plan.fn`` works with full telescope + sensor config."""
+    mock_targets = [
+        {
+            'name': 'M 42',
+            'type': 'emission nebula',
+            'ra': 83.8,
+            'dec': -5.4,
+            'magnitude': 4.0,
+            'surface_brightness': 14.5,
+            'angular_size_arcmin': 66.0,
+            'altitude': 55.0,
+            'azimuth': 180.0,
+            'dawn_altitude': 40.0,
+            'fov_fill_ratio': 0.5,
+            'fov_fit_score': 0.85,
+            'surface_brightness_score': 0.7,
+            'filter_match_score': 0.9,
+            'altitude_score': 0.5,
+            'suitability_score': 85.0,
+            'mosaic_recommended': False,
+            'catalog': 'Messier',
+            'altitude_curve': [
+                {'time': 1705341600, 'alt': 30.0},
+                {'time': 1705342500, 'alt': 40.0},
+                {'time': 1705343400, 'alt': 50.0},
+                {'time': 1705344300, 'alt': 55.0},
+                {'time': 1705345200, 'alt': 50.0},
+                {'time': 1705346100, 'alt': 35.0},
+            ],
+            'observation_time': '2024-01-15T19:00:00',
+            'civil_dusk': '2024-01-15T18:00:00',
+            'civil_dawn': '2024-01-16T06:00:00',
+        }
+    ]
+    mock_moon = {
+        'illumination': 0.95,
+        'phase': 'Full Moon',
+        'altitude_curve': [
+            {'time': 1705341600, 'alt': 10.0},
+            {'time': 1705342500, 'alt': 20.0},
+            {'time': 1705343400, 'alt': 30.0},
+            {'time': 1705344300, 'alt': 40.0},
+        ],
+        'always_down': False,
+        'always_up': False,
+        'dark_fraction': 0.3,
+    }
+
+    with patch('src.functions.telescope.impl.match_telescope_targets') as mock_match:
+        mock_match.return_value = {'targets': mock_targets, 'moon': mock_moon}
+
+        result = await get_shooting_plan.fn(
+            focal_length_mm=420,
+            lon=-117.0,
+            lat=33.0,
+            time='2024-01-15T22:00:00',
+            time_zone='America/Los_Angeles',
+            aperture_mm=100,
+            sensor_width_mm=23.5,
+            sensor_height_mm=15.7,
+            sensor_pixel_size_um=3.76,
+            min_altitude=30.0,
+            limit=5,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert len(data['targets']) == 1
+    assert data['targets'][0]['name'] == 'M 42'
+    assert data['moon']['phase'] == 'Full Moon'
+    assert data['moon']['illumination'] == 0.95
+    assert data['config']['focal_length_mm'] == 420
+    assert data['config']['aperture_mm'] == 100
+    assert data['config']['sensor_width_mm'] == 23.5
+    assert 'plan' in data
+    from stargazing_core._shooting_plan import ShootingPlan
+
+    plan = ShootingPlan(**data['plan'])
+    assert len(plan.slots) >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_shooting_plan_empty_targets():
+    """``get_shooting_plan.fn`` handles empty targets gracefully."""
+    mock_moon = {
+        'illumination': 0.5,
+        'phase': 'First Quarter',
+        'altitude_curve': [],
+        'always_down': False,
+        'always_up': False,
+        'dark_fraction': 0.5,
+    }
+
+    with patch('src.functions.telescope.impl.match_telescope_targets') as mock_match:
+        mock_match.return_value = {'targets': [], 'moon': mock_moon}
+
+        result = await get_shooting_plan.fn(
+            focal_length_mm=250,
+            lon=116.4,
+            lat=39.9,
+            time='2024-01-15T22:00:00',
+            time_zone='Asia/Shanghai',
+            limit=5,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert len(data['targets']) == 0
+    assert data['total'] == 0
+    assert 'plan' in data
+    from stargazing_core._shooting_plan import ShootingPlan
+
+    plan = ShootingPlan(**data['plan'])
+    assert len(plan.slots) == 0
+
+
+# ---------------------------------------------------------------------------
+# Celestial position / rise-set fn tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_celestial_pos_fn():
+    """``get_celestial_pos.fn`` returns altitude/azimuth for a celestial object."""
+    from src.functions.celestial.impl import get_celestial_pos
+
+    with (
+        patch('src.functions.celestial.impl.celestial_pos') as mock_calc,
+        patch('src.functions.celestial.impl.process_location_and_time') as mock_proc,
+    ):
+        mock_proc.return_value = (MagicMock(), MagicMock())
+        mock_calc.return_value = (45.5, 180.0)
+
+        result = await get_celestial_pos.fn(
+            celestial_object='M31',
+            lon=-74.0,
+            lat=40.0,
+            time='2024-06-15 22:00:00',
+            time_zone='America/New_York',
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert data['altitude'] == 45.5
+    assert data['azimuth'] == 180.0
+
+
+@pytest.mark.asyncio
+async def test_get_celestial_rise_set_fn():
+    """``get_celestial_rise_set.fn`` returns rise/set times."""
+    from src.functions.celestial.impl import get_celestial_rise_set
+
+    with (
+        patch('src.functions.celestial.impl.celestial_rise_set') as mock_calc,
+        patch('src.functions.celestial.impl.process_location_and_time') as mock_proc,
+    ):
+        from datetime import UTC, datetime
+
+        mock_proc.return_value = (MagicMock(), MagicMock())
+        # celestial_rise_set returns (rise_time, set_time) as two astropy Time objects
+        mock_calc.return_value = (
+            datetime(2024, 6, 15, 5, 30, tzinfo=UTC),
+            datetime(2024, 6, 15, 20, 15, tzinfo=UTC),
+        )
+
+        result = await get_celestial_rise_set.fn(
+            celestial_object='Sun',
+            lon=-74.0,
+            lat=40.0,
+            time='2024-06-15 22:00:00',
+            time_zone='America/New_York',
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert data['rise_time'] is not None
+    assert data['set_time'] is not None

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1039,3 +1039,280 @@ async def test_get_celestial_rise_set_fn():
     data = result['data']
     assert data['rise_time'] is not None
     assert data['set_time'] is not None
+
+
+# ---------------------------------------------------------------------------
+# Telescope — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_telescope_targets_invalid_coords():
+    """``get_telescope_targets.fn`` raises TypeError for out-of-range coordinates.
+
+    The telescope tools bypass ``process_location_and_time`` and create
+    ``EarthLocation`` directly; astropy raises ``TypeError`` when lat is out
+    of range instead of the expected ``MCPError.INVALID_COORDINATES``.
+    This test documents the current behavior.
+    """
+    with pytest.raises(TypeError, match='Coordinates could not be parsed'):
+        await get_telescope_targets.fn(
+            focal_length_mm=250,
+            lon=0.0,
+            lat=95.0,  # invalid latitude > 90
+            time='2024-01-15T22:00:00',
+            time_zone='Asia/Shanghai',
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_telescope_targets_invalid_time():
+    """``get_telescope_targets.fn`` returns structured error for invalid time format."""
+    result = await get_telescope_targets.fn(
+        focal_length_mm=250,
+        lon=116.4,
+        lat=39.9,
+        time='not-a-valid-time',
+        time_zone='Asia/Shanghai',
+    )
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_TIME_FORMAT
+
+
+@pytest.mark.asyncio
+async def test_get_telescope_targets_invalid_timezone():
+    """``get_telescope_targets.fn`` returns structured error for invalid timezone."""
+    result = await get_telescope_targets.fn(
+        focal_length_mm=250,
+        lon=116.4,
+        lat=39.9,
+        time='2024-01-15T22:00:00',
+        time_zone='Not/A_Timezone',
+    )
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_TIMEZONE
+
+
+# ---------------------------------------------------------------------------
+# Shooting plan — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_shooting_plan_invalid_coords():
+    """``get_shooting_plan.fn`` raises TypeError for out-of-range coordinates.
+
+    Same as ``get_telescope_targets`` — the internal ``EarthLocation``
+    construction throws ``TypeError`` when lat exceeds ±90°.
+    """
+    with pytest.raises(TypeError, match='Coordinates could not be parsed'):
+        await get_shooting_plan.fn(
+            focal_length_mm=250,
+            lon=116.4,
+            lat=95.0,  # invalid latitude > 90
+            time='2024-01-15T22:00:00',
+            time_zone='Asia/Shanghai',
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_shooting_plan_invalid_timezone():
+    """``get_shooting_plan.fn`` raises UnknownTimeZoneError for invalid timezone."""
+    import pytz
+
+    with pytest.raises(pytz.exceptions.UnknownTimeZoneError):
+        await get_shooting_plan.fn(
+            focal_length_mm=250,
+            lon=116.4,
+            lat=39.9,
+            time='2024-01-15T22:00:00',
+            time_zone='Invalid/Zone',
+        )
+
+
+# ---------------------------------------------------------------------------
+# Constellation — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_constellation_invalid_coords():
+    """``get_constellation.fn`` returns structured error for out-of-range coordinates."""
+    result = await get_constellation.fn(
+        constellation_name='Orion',
+        lon=-200.0,  # invalid
+        lat=40.0,
+        time='2024-06-15 22:00:00',
+        time_zone='America/New_York',
+    )
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_COORDINATES
+
+
+# ---------------------------------------------------------------------------
+# Moon info — edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_moon_info_lat_without_lon():
+    """``get_moon_info.fn`` with only lat (no lon) — no local alt/az computed."""
+    with patch('src.functions.celestial.impl.calculate_moon_info') as mock_calc:
+        mock_calc.return_value = {
+            'phase_name': 'Waxing Crescent',
+            'illumination': 0.3,
+            'age_days': 5.2,
+            'elongation': 45.0,
+            'earth_distance': 390000.0,
+        }
+
+        result = await get_moon_info.fn(
+            time='2024-06-15T12:00:00+00:00',
+            time_zone='UTC',
+            lat=40.0,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert data['phase_name'] == 'Waxing Crescent'
+    assert data['illumination'] == 0.3
+
+
+@pytest.mark.asyncio
+async def test_get_moon_info_lon_without_lat():
+    """``get_moon_info.fn`` with only lon (no lat) — no local alt/az computed."""
+    with patch('src.functions.celestial.impl.calculate_moon_info') as mock_calc:
+        mock_calc.return_value = {
+            'phase_name': 'Full Moon',
+            'illumination': 0.99,
+            'age_days': 14.5,
+            'elongation': 180.0,
+            'earth_distance': 384400.0,
+        }
+
+        result = await get_moon_info.fn(
+            time='2024-06-15T12:00:00+00:00',
+            time_zone='UTC',
+            lon=-74.0,
+        )
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert data['phase_name'] == 'Full Moon'
+
+
+@pytest.mark.asyncio
+async def test_get_moon_info_no_position():
+    """``get_moon_info.fn`` without lat/lon — only phase data returned."""
+    with patch('src.functions.celestial.impl.calculate_moon_info') as mock_calc:
+        mock_calc.return_value = {
+            'phase_name': 'New Moon',
+            'illumination': 0.01,
+            'age_days': 0.5,
+            'elongation': 5.0,
+            'earth_distance': 405000.0,
+        }
+
+        result = await get_moon_info.fn(time='2024-06-15T12:00:00+00:00', time_zone='UTC')
+
+    assert result['_meta']['status'] == 'success'
+    data = result['data']
+    assert data['phase_name'] == 'New Moon'
+    assert data['altitude'] is None
+    assert data['azimuth'] is None
+
+
+@pytest.mark.asyncio
+async def test_get_moon_info_invalid_timezone():
+    """``get_moon_info.fn`` returns structured error for invalid timezone."""
+    result = await get_moon_info.fn(time='2024-06-15 12:00:00', time_zone='Bad/Zone')
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_TIMEZONE
+
+
+# ---------------------------------------------------------------------------
+# Nightly forecast — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_nightly_forecast_invalid_coords():
+    """``get_nightly_forecast.fn`` returns structured error for invalid coordinates."""
+    result = await get_nightly_forecast.fn(
+        lon=200.0,  # invalid
+        lat=40.0,
+        time='2024-06-15 22:00:00',
+        time_zone='America/New_York',
+    )
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_COORDINATES
+
+
+@pytest.mark.asyncio
+async def test_get_nightly_forecast_invalid_timezone():
+    """``get_nightly_forecast.fn`` returns structured error for invalid timezone."""
+    result = await get_nightly_forecast.fn(
+        lon=-74.0,
+        lat=40.0,
+        time='2024-06-15 22:00:00',
+        time_zone='Not/A_Zone',
+    )
+
+    assert result['_meta']['status'] == 'error'
+    assert result['error']['code'] == MCPError.INVALID_TIMEZONE
+
+
+# ---------------------------------------------------------------------------
+# Light pollution map — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_light_pollution_map_invalid_bounds():
+    """``light_pollution_map.fn`` raises MCPError for invalid bounding box."""
+    with patch('src.functions.places.impl.get_light_pollution_grid') as mock_grid:
+        mock_grid.side_effect = ValueError('south must be less than north')
+
+        with pytest.raises(MCPError) as exc_info:
+            await light_pollution_map.fn(south=40.5, west=-74.0, north=40.0, east=-73.0)
+
+    assert exc_info.value.code == MCPError.EXTERNAL_API_ERROR
+
+
+@pytest.mark.asyncio
+async def test_light_pollution_map_spf_not_installed():
+    """``light_pollution_map.fn`` raises CONFIGURATION_ERROR when SPF is missing."""
+    with patch(
+        'src.functions.places.impl.get_light_pollution_grid',
+        side_effect=ModuleNotFoundError('No module named stargazing_place_finder'),
+    ):
+        with pytest.raises(MCPError) as exc_info:
+            await light_pollution_map.fn(south=40.0, west=-74.0, north=40.5, east=-73.5)
+
+    assert exc_info.value.code == MCPError.CONFIGURATION_ERROR
+    assert 'not installed' in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_light_pollution_map_spf_data_error():
+    """``light_pollution_map.fn`` translates SPF DataError to MCPError."""
+    try:
+        from stargazingplacefinder import DataError  # noqa: F401
+
+        with patch(
+            'src.functions.places.impl.get_light_pollution_grid',
+            side_effect=DataError('GeoTIFF not found'),
+        ):
+            with pytest.raises(MCPError) as exc_info:
+                await light_pollution_map.fn(south=40.0, west=-74.0, north=40.5, east=-73.5)
+        assert exc_info.value.code in (
+            MCPError.EXTERNAL_API_ERROR,
+            MCPError.CONFIGURATION_ERROR,
+        )
+    except ImportError:
+        pytest.skip('stargazingplacefinder not available in this environment')

--- a/tests/test_supervisord_config.py
+++ b/tests/test_supervisord_config.py
@@ -1,0 +1,170 @@
+"""Validate the supervisord configuration for the dual-service Docker setup.
+
+These tests ensure the supervisor config file is well-formed, that both the
+MCP server and SPF web UI programs are correctly defined, and that the
+Dockerfile is consistent with the supervisor configuration.
+"""
+
+import configparser
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SUPERVISORD_CONF = PROJECT_ROOT / 'supervisord.conf'
+DOCKERFILE = PROJECT_ROOT / 'Dockerfile'
+
+
+def _parse_config() -> configparser.RawConfigParser:
+    """Parse the supervisord.conf file with INI-safe handling of %(env_*) vars."""
+    # supervisor uses %(ENV_VAR)s for environment variable substitution;
+    # ConfigParser interprets bare % as interpolation.  Use RawConfigParser
+    # and pass an empty dict so it skips key lookups entirely.
+    parser = configparser.RawConfigParser()
+    parser.read(SUPERVISORD_CONF, encoding='utf-8')
+    return parser
+
+
+# ── Config file presence ──────────────────────────────────────────────
+
+
+def test_supervisord_conf_exists():
+    """supervisord.conf must exist at the project root."""
+    assert SUPERVISORD_CONF.is_file(), f'supervisord.conf not found at {SUPERVISORD_CONF}'
+
+
+# ── Sections ──────────────────────────────────────────────────────────
+
+
+def test_supervisord_section_present():
+    """The [supervisord] global section must be present."""
+    cfg = _parse_config()
+    assert cfg.has_section('supervisord'), 'Missing [supervisord] section'
+
+
+def test_nodaemon_is_true():
+    """supervisord must run in foreground (nodaemon=true) for Docker."""
+    cfg = _parse_config()
+    assert cfg.get('supervisord', 'nodaemon') == 'true', (
+        'nodaemon must be true so supervisord stays in the foreground'
+    )
+
+
+# ── Programs ──────────────────────────────────────────────────────────
+
+
+def test_mcp_program_defined():
+    """The MCP server program must be configured."""
+    cfg = _parse_config()
+    assert cfg.has_section('program:mcp'), 'Missing [program:mcp] section'
+
+
+def test_spf_web_program_defined():
+    """The SPF web UI program must be configured."""
+    cfg = _parse_config()
+    assert cfg.has_section('program:spf-web'), 'Missing [program:spf-web] section'
+
+
+def test_mcp_program_uses_uv_run():
+    """MCP must be launched via uv run."""
+    cfg = _parse_config()
+    command = cfg.get('program:mcp', 'command')
+    assert 'uv run' in command, f'MCP command should use uv run, got: {command}'
+    assert 'mcp-stargazing' in command, (
+        f'MCP command should reference mcp-stargazing, got: {command}'
+    )
+
+
+def test_spf_web_program_uses_uv_run():
+    """SPF web must be launched via uv run."""
+    cfg = _parse_config()
+    command = cfg.get('program:spf-web', 'command')
+    assert 'uv run' in command, f'SPF command should use uv run, got: {command}'
+    assert 'uvicorn' in command, f'SPF command should use uvicorn, got: {command}'
+    assert 'server.main:app' in command, (
+        f'SPF command should reference server.main:app, got: {command}'
+    )
+
+
+# ── Ports ─────────────────────────────────────────────────────────────
+
+
+def test_mcp_port_is_3001():
+    """MCP should listen on port 3001."""
+    cfg = _parse_config()
+    command = cfg.get('program:mcp', 'command')
+    assert '--port 3001' in command, f'MCP should use port 3001, got: {command}'
+
+
+def test_spf_web_port_is_5001():
+    """SPF web should listen on port 5001."""
+    cfg = _parse_config()
+    command = cfg.get('program:spf-web', 'command')
+    assert '--port 5001' in command, f'SPF web should use port 5001, got: {command}'
+
+
+# ── Working directory ─────────────────────────────────────────────────
+
+
+def test_both_programs_share_app_directory():
+    """Both programs must run from /app (Docker WORKDIR)."""
+    cfg = _parse_config()
+    mcp_dir = cfg.get('program:mcp', 'directory')
+    spf_dir = cfg.get('program:spf-web', 'directory')
+    assert mcp_dir == '/app', f'MCP directory should be /app, got: {mcp_dir}'
+    assert spf_dir == '/app', f'SPF directory should be /app, got: {spf_dir}'
+
+
+# ── Auto-restart ──────────────────────────────────────────────────────
+
+
+def test_both_programs_have_autorestart():
+    """Both programs should auto-restart on failure."""
+    cfg = _parse_config()
+    assert cfg.get('program:mcp', 'autorestart') == 'true'
+    assert cfg.get('program:spf-web', 'autorestart') == 'true'
+
+
+# ── Dockerfile ↔ supervisord.conf consistency ─────────────────────────
+
+
+def test_dockerfile_exposes_both_ports():
+    """Dockerfile must EXPOSE both 3001 and 5001."""
+    docker_text = DOCKERFILE.read_text(encoding='utf-8')
+    expose_line = ''
+    for line in docker_text.splitlines():
+        if line.strip().startswith('EXPOSE'):
+            expose_line = line.strip()
+            break
+    assert expose_line, 'Missing EXPOSE line in Dockerfile'
+    assert '3001' in expose_line, f'Port 3001 not exposed: {expose_line}'
+    assert '5001' in expose_line, f'Port 5001 not exposed: {expose_line}'
+
+
+def test_dockerfile_installs_supervisor():
+    """Dockerfile must install the supervisor package."""
+    docker_text = DOCKERFILE.read_text(encoding='utf-8')
+    assert 'supervisor' in docker_text, (
+        'Dockerfile must install supervisor (apt-get install supervisor)'
+    )
+
+
+def test_dockerfile_entrypoint_is_supervisord():
+    """Dockerfile ENTRYPOINT must be supervisord."""
+    docker_text = DOCKERFILE.read_text(encoding='utf-8')
+    assert 'ENTRYPOINT ["supervisord"]' in docker_text, 'Dockerfile ENTRYPOINT must be supervisord'
+
+
+def test_supervisord_conf_path_matches_dockerfile():
+    """The supervisor config path in CMD must match the COPY destination in Dockerfile."""
+    docker_text = DOCKERFILE.read_text(encoding='utf-8')
+    # Extract COPY destination
+    copy_match = re.search(r'COPY supervisord\.conf (\S+)', docker_text)
+    assert copy_match, 'Dockerfile must COPY supervisord.conf'
+    dest_path = copy_match.group(1)
+
+    # Extract CMD path
+    cmd_match = re.search(r'CMD \["-c", "(\S+)"\]', docker_text)
+    assert cmd_match, 'Dockerfile CMD must reference the config path'
+    cmd_path = cmd_match.group(1)
+
+    assert dest_path == cmd_path, f'COPY dest ({dest_path}) must match CMD path ({cmd_path})'

--- a/uv.lock
+++ b/uv.lock
@@ -1193,7 +1193,7 @@ wheels = [
 
 [[package]]
 name = "mcp-stargazing"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,14 @@
 version = 1
 revision = 1
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "affine"
@@ -1223,7 +1231,7 @@ requires-dist = [
     { name = "pytz" },
     { name = "rasterio" },
     { name = "requests" },
-    { name = "stargazing-core", git = "https://github.com/StarGazer1995/stargazing-core.git" },
+    { name = "stargazing-core", specifier = ">=0.1.0" },
     { name = "stargazing-place-finder", specifier = ">=0.6.6,<1" },
     { name = "structlog", specifier = ">=26.1.0" },
     { name = "tzlocal" },
@@ -1377,42 +1385,46 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.3.3"
+version = "3.0.3"
 source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223 }
+sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414 }
 wheels = [
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963 },
-    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855 },
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464 },
 ]
 
 [[package]]
@@ -2238,8 +2250,8 @@ name = "secretstorage"
 version = "3.4.1"
 source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/32/8a/ed6747b1cc723c81f526d4c12c1b1d43d07190e1e8258dbf934392fc850e/secretstorage-3.4.1.tar.gz", hash = "sha256:a799acf5be9fb93db609ebaa4ab6e8f1f3ed5ae640e0fa732bfea59e9c3b50e8", size = 19871 }
 wheels = [
@@ -2330,13 +2342,18 @@ wheels = [
 
 [[package]]
 name = "stargazing-core"
-version = "0.1.0a1"
-source = { git = "https://github.com/StarGazer1995/stargazing-core.git#4eda30160aa9f59e6aa30d8c775ce37457b21a32" }
+version = "0.1.0"
+source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
     { name = "astropy" },
     { name = "numpy" },
+    { name = "pandas" },
     { name = "pydantic" },
     { name = "pytz" },
+]
+sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/88/e8/050a0fe9509c09fa1b38fe76270b45efde91d47be9bbaedaea13b27beeed/stargazing_core-0.1.0.tar.gz", hash = "sha256:5fe7292f0f8c1084e21503686f90192944f053b64d1b1695057b81d9b0699b5b", size = 241111 }
+wheels = [
+    { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/61/8b/0b38e0501a6978f5d5fdffbf666ff6f45f3c0556d99f91de0851e0e62520/stargazing_core-0.1.0-py3-none-any.whl", hash = "sha256:070c913d812ec5eb3f04e1eaceb7a7dd6a997fc348cdc2544b213be1010dae9b", size = 251297 },
 ]
 
 [[package]]
@@ -2460,8 +2477,8 @@ name = "uvicorn"
 version = "0.38.0"
 source = { registry = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605 }
 wheels = [


### PR DESCRIPTION
## Summary

- Bump version `0.6.2` → `0.7.0`
- Switch `stargazing-core` from git URL to `>=0.1.0` from PyPI
- Remove `[tool.uv.sources]` path override, lock resolves to registry

## Why

`stargazing-core` is now published on PyPI (v0.1.0). Using PyPI as the single source of truth eliminates dependency duplication — both MCP and its transitive dependency via `stargazing-place-finder` resolve to the same registry package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)