### PR TITLE
ci: add Docker smoke test — verify MCP + SPF dual-service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,35 +103,9 @@ jobs:
       - name: Build Production Image
         run: docker build --target production -t prod-image .
 
-      - name: Upload Test Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-report
-          path: reports/test-report.xml
-
-      - name: Upload Coverage Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: reports/coverage.xml
-
-  smoke-test:
-    name: "Smoke test — dual-service"
-    needs: test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build production image
-        run: docker build --target production -t mcp-stargazing:smoke .
-
-      - name: Start container and verify both services
+      - name: Smoke test — start container and verify dual-service
         run: |
-          docker run -d --name mcp-smoke -p 13001:3001 -p 15001:5001 mcp-stargazing:smoke
+          docker run -d --name mcp-smoke -p 13001:3001 -p 15001:5001 prod-image
           trap 'docker logs mcp-smoke; docker rm -f mcp-smoke' EXIT
 
           echo "Waiting for MCP server on :3001..."
@@ -147,17 +121,13 @@ jobs:
           MCP_HEALTH=$(curl -s http://127.0.0.1:13001/health)
           echo "MCP health: $MCP_HEALTH"
           echo "$MCP_HEALTH" | grep -q '"status":"healthy"' && echo "✅ MCP: status = healthy"
-          echo "$MCP_HEALTH" | grep -q '"version"' && echo "✅ MCP: version field present"
 
           # Verify MCP tools/list
           TOOLS=$(curl -s -X POST http://127.0.0.1:13001/shttp \
             -H 'Content-Type: application/json' \
-            -H 'Accept: application/json' \
             -d '{"jsonrpc":"2.0","id":"1","method":"tools/list"}')
-          echo "tools/list response length: $(echo $TOOLS | wc -c)"
-          echo "$TOOLS" | grep -q '"get_telescope_targets"' && echo "✅ tools/list: telescope targets tool registered"
-          echo "$TOOLS" | grep -q '"get_shooting_plan"' && echo "✅ tools/list: shooting plan tool registered"
-          echo "$TOOLS" | grep -q '"get_best_stargazing_plan"' && echo "✅ tools/list: planning tool registered"
+          echo "$TOOLS" | grep -q '"get_telescope_targets"' && echo "✅ MCP: telescope targets tool"
+          echo "$TOOLS" | grep -q '"get_shooting_plan"' && echo "✅ MCP: shooting plan tool"
 
           echo "Waiting for SPF web on :5001..."
           for i in $(seq 1 30); do
@@ -171,16 +141,23 @@ jobs:
           # Verify SPF health
           SPF_HEALTH=$(curl -s http://127.0.0.1:15001/api/health)
           echo "SPF health: $SPF_HEALTH"
-          echo "$SPF_HEALTH" | grep -q '"status"' && echo "✅ SPF: health endpoint OK"
+          echo "$SPF_HEALTH" | grep -q '"status"' && echo "✅ SPF: health OK"
 
           # Verify SPF web UI
-          HTML=$(curl -s http://127.0.0.1:15001/)
-          echo "$HTML" | grep -q '观星地点查找器' && echo "✅ SPF: Stargazing Place Finder page"
-          echo "$HTML" | grep -q 'leaflet' && echo "✅ SPF: Leaflet map loaded"
+          curl -s http://127.0.0.1:15001/ | grep -q '观星地点查找器' && echo "✅ SPF: web UI loaded"
 
-          # Verify SPF static assets
-          JS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:15001/assets/js/app.js)
-          echo "SPF assets/js/app.js → HTTP $JS_STATUS"
-          test "$JS_STATUS" = "200" && echo "✅ SPF: Static JS served"
+          echo "✅ Smoke test complete"
 
-          echo "✅ Smoke test complete — MCP + SPF both operational"
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: reports/test-report.xml
+
+      - name: Upload Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: reports/coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,71 @@ jobs:
         with:
           name: coverage-report
           path: reports/coverage.xml
+
+  smoke-test:
+    name: "Smoke test — dual-service"
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build production image
+        run: docker build --target production -t mcp-stargazing:smoke .
+
+      - name: Start container and verify both services
+        run: |
+          docker run -d --name mcp-smoke -p 13001:3001 -p 15001:5001 mcp-stargazing:smoke
+          trap 'docker logs mcp-smoke; docker rm -f mcp-smoke' EXIT
+
+          echo "Waiting for MCP server on :3001..."
+          for i in $(seq 1 30); do
+            if curl -s http://127.0.0.1:13001/health > /dev/null 2>&1; then
+              echo "✅ MCP server responded in ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+          # Verify MCP health
+          MCP_HEALTH=$(curl -s http://127.0.0.1:13001/health)
+          echo "MCP health: $MCP_HEALTH"
+          echo "$MCP_HEALTH" | grep -q '"status":"healthy"' && echo "✅ MCP: status = healthy"
+          echo "$MCP_HEALTH" | grep -q '"version"' && echo "✅ MCP: version field present"
+
+          # Verify MCP tools/list
+          TOOLS=$(curl -s -X POST http://127.0.0.1:13001/shttp \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            -d '{"jsonrpc":"2.0","id":"1","method":"tools/list"}')
+          echo "tools/list response length: $(echo $TOOLS | wc -c)"
+          echo "$TOOLS" | grep -q '"get_telescope_targets"' && echo "✅ tools/list: telescope targets tool registered"
+          echo "$TOOLS" | grep -q '"get_shooting_plan"' && echo "✅ tools/list: shooting plan tool registered"
+          echo "$TOOLS" | grep -q '"get_best_stargazing_plan"' && echo "✅ tools/list: planning tool registered"
+
+          echo "Waiting for SPF web on :5001..."
+          for i in $(seq 1 30); do
+            if curl -s http://127.0.0.1:15001/api/health > /dev/null 2>&1; then
+              echo "✅ SPF web responded in ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+          # Verify SPF health
+          SPF_HEALTH=$(curl -s http://127.0.0.1:15001/api/health)
+          echo "SPF health: $SPF_HEALTH"
+          echo "$SPF_HEALTH" | grep -q '"status"' && echo "✅ SPF: health endpoint OK"
+
+          # Verify SPF web UI
+          HTML=$(curl -s http://127.0.0.1:15001/)
+          echo "$HTML" | grep -q '观星地点查找器' && echo "✅ SPF: Stargazing Place Finder page"
+          echo "$HTML" | grep -q 'leaflet' && echo "✅ SPF: Leaflet map loaded"
+
+          # Verify SPF static assets
+          JS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:15001/assets/js/app.js)
+          echo "SPF assets/js/app.js → HTTP $JS_STATUS"
+          test "$JS_STATUS" = "200" && echo "✅ SPF: Static JS served"
+
+          echo "✅ Smoke test complete — MCP + SPF both operational"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-stargazing"
-version = "0.7.1"
+version = "0.7.2"
 description = "An MCP server that provides real-time astronomical data, smart stargazing planning, and light pollution analysis for AI agents."
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

Adds `smoke-test` job that starts the production Docker container and verifies both services:

**MCP (:3001)**:
- `/health` returns `{"status":"healthy"}`
- `tools/list` includes telescope targets, shooting plan, planning tools

**SPF (:5001)**:
- `/api/health` returns valid JSON
- `/` returns Stargazing Place Finder page (观星地点查找器, Leaflet)
- `/assets/js/app.js` returns HTTP 200

## Why

Without this, CI only tests that code compiles — it doesn't verify the supervisord dual-service setup actually works at runtime. This would catch:
- Missing `server.main:app` module (SPF version mismatch)
- Missing frontend assets (source/ packaging issue)
- supervisord config not starting both processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)